### PR TITLE
Harden Neon + Oracle hosted deployment

### DIFF
--- a/.github/workflows/neon-hosted-refresh.yml
+++ b/.github/workflows/neon-hosted-refresh.yml
@@ -13,14 +13,18 @@ jobs:
   refresh:
     name: Refresh hosted Neon slice
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 120
     permissions:
       contents: read
     env:
       NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
       ONNX_MODEL_DIR: data/models/all-MiniLM-L6-v2-onnx
+      SCRAPE_YEAR: ""
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set scrape year
+        run: echo "SCRAPE_YEAR=$(date +%Y)" >> "$GITHUB_ENV"
 
       - uses: actions/setup-python@v5
         with:
@@ -37,13 +41,14 @@ jobs:
           restore-keys: poetry-hosted-refresh-${{ runner.os }}-
 
       - name: Cache ONNX bundle
+        id: onnx-cache
         uses: actions/cache@v4
         with:
           path: data/models/all-MiniLM-L6-v2-onnx
           key: hosted-onnx-${{ runner.os }}-all-MiniLM-L6-v2-v1
 
       - name: Install dependencies
-        run: poetry install --with ml,ml_torch
+        run: poetry install --with ml
 
       - name: Validate required secrets
         run: |
@@ -53,15 +58,15 @@ jobs:
           fi
 
       - name: Export ONNX bundle if cache is cold
+        if: steps.onnx-cache.outputs.cache-hit != 'true'
         run: |
-          if [ ! -f "$ONNX_MODEL_DIR/model.onnx" ]; then
-            poetry run python -m src.cli embed-export-onnx all-MiniLM-L6-v2 --output-dir "$ONNX_MODEL_DIR"
-          fi
+          poetry install --with ml_torch
+          poetry run python -m src.cli embed-export-onnx all-MiniLM-L6-v2 --output-dir "$ONNX_MODEL_DIR"
 
-      - name: Scrape current 2026 jobs into Neon
+      - name: Scrape current year jobs into Neon
         run: |
           poetry run python -m src.cli scrape-historical \
-            --year 2026 \
+            --year "$SCRAPE_YEAR" \
             --resume \
             --db "$NEON_DATABASE_URL"
 
@@ -77,7 +82,6 @@ jobs:
         run: |
           poetry run python -m src.cli pg-purge-hosted \
             --target "$NEON_DATABASE_URL" \
-            --min-posted-date 2026-01-01 \
             --max-age-days 90
 
       - name: Verify hosted retention and embeddings
@@ -94,7 +98,10 @@ jobs:
                       SELECT COUNT(*)
                       FROM jobs
                       WHERE posted_date IS NULL
-                         OR posted_date < GREATEST(DATE '2026-01-01', CURRENT_DATE - INTERVAL '90 days')
+                         OR posted_date < GREATEST(
+                              DATE_TRUNC('year', CURRENT_DATE)::date,
+                              CURRENT_DATE - INTERVAL '90 days'
+                            )
                       """
                   )
                   old_jobs = cur.fetchone()[0]
@@ -112,3 +119,13 @@ jobs:
 
           print(f"Verified hosted slice: {job_embeddings} job embeddings, retention window enforced")
           PY
+
+      - name: Report failure
+        if: failure()
+        run: |
+          echo "::error::Neon hosted refresh failed for year $SCRAPE_YEAR. Check the logs above for details."
+          echo "## Neon Hosted Refresh Failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Year**: $SCRAPE_YEAR" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Time**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,6 @@
-# Production overrides for homelab deployment.
+# Production overrides for homelab (SQLite + FAISS) deployment.
+# This is NOT for Oracle + Neon hosted deployments — those use `docker run`
+# directly per docs/neon-oracle-hosted-deploy.md.
 # Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 services:

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -67,17 +67,17 @@ ENV MCF_DB_PATH=/app/data/mcf_jobs.db \
     MCF_INDEX_DIR=/app/data/embeddings \
     MCF_EMBEDDING_BACKEND=onnx \
     MCF_ONNX_MODEL_DIR=/opt/mcf/models/all-MiniLM-L6-v2-onnx \
-    MCF_CORS_ORIGINS=* \
     MCF_RATE_LIMIT_RPM=100 \
     MCF_SQLITE_JOURNAL_MODE=delete \
     HF_HOME=/app/.cache/huggingface
 
 EXPOSE 8000
 
-# start-period=60s: FAISS index loading takes 5-30s on startup; the
-# ONNX session/tokenizer still initialize lazily on first search.
+# start-period=120s: FAISS/pgvector index loading takes 5-30s on startup;
+# the ONNX session/tokenizer still initialize lazily on first search.
+# 120s accommodates cold starts on Oracle A1 with pgvector connections.
 # Failures during start-period don't count toward retries.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
 # Single worker: each worker duplicates FAISS indexes in RAM (~2GB).

--- a/docs/neon-oracle-hosted-deploy.md
+++ b/docs/neon-oracle-hosted-deploy.md
@@ -10,7 +10,7 @@ Local Postgres remains the full archive and the primary source of truth. The
 hosted database is a lean serving slice that keeps only rows where:
 
 ```text
-posted_date >= max(2026-01-01, today - 90 days)
+posted_date >= max(Jan 1 of current year, today - 90 days)
 ```
 
 The hosted slice keeps only `job` embeddings. `skill` and `company` embeddings
@@ -65,13 +65,15 @@ export NEON_DATABASE_URL='postgresql://<neon-dsn>'
 poetry run python -m src.cli pg-seed-hosted \
   --source "$LOCAL_DATABASE_URL" \
   --target "$NEON_DATABASE_URL" \
-  --min-posted-date 2026-01-01 \
   --max-age-days 90
 ```
 
+The `--min-posted-date` defaults to January 1 of the current year. Override it
+only if you need a different floor.
+
 The hosted seed keeps the retained `jobs`, `job` embeddings, and one resumable
-2026 historical scrape session when one exists locally. It does not copy
-`skill` or `company` embeddings.
+historical scrape session for the current year when one exists locally. It does
+not copy `skill` or `company` embeddings.
 
 Verify the hosted contents with SQL:
 
@@ -91,7 +93,7 @@ SELECT pg_size_pretty(pg_database_size(current_database())) AS database_size;
 
 Expected shape:
 
-- only recent 2026-floor jobs are present
+- only recent jobs from the current year are present
 - only `job` rows exist in `embeddings`
 - the database size stays comfortably below Neon Free storage limits
 
@@ -113,16 +115,19 @@ dispatch.
 Each scheduled run performs:
 
 ```bash
-poetry run python -m src.cli scrape-historical --year 2026 --resume --db "$NEON_DATABASE_URL"
+YEAR=$(date +%Y)
+poetry run python -m src.cli scrape-historical --year "$YEAR" --resume --db "$NEON_DATABASE_URL"
 poetry run python -m src.cli embed-sync --db "$NEON_DATABASE_URL" --embedding-backend onnx --onnx-model-dir data/models/all-MiniLM-L6-v2-onnx --no-update-index
-poetry run python -m src.cli pg-purge-hosted --target "$NEON_DATABASE_URL" --min-posted-date 2026-01-01 --max-age-days 90
+poetry run python -m src.cli pg-purge-hosted --target "$NEON_DATABASE_URL" --max-age-days 90
 ```
 
 This is intentionally a scheduled batch job, not a daemon:
 
 - Neon does not run background processes
 - the hosted slice stays bounded because old rows are purged each run
-- `scrape-historical --resume` can continue from the hosted 2026 session state
+- `scrape-historical --resume` can continue from the hosted session state
+- the scrape year and purge cutoff are computed dynamically — no manual update
+  needed on year rollover
 
 ## 6. Create the Oracle API VM
 
@@ -139,8 +144,8 @@ for this backend and ONNX runtime.
 Allow inbound traffic on:
 
 - `22` for SSH
-- `8000` for direct API testing
-- optionally `80` and `443` if you place Nginx or Caddy in front
+- `80` and `443` for HTTPS (Caddy reverse proxy)
+- optionally `8000` for direct API testing (can be closed after Caddy is set up)
 
 ## 7. Install Docker on Oracle
 
@@ -173,18 +178,32 @@ cd jobs-intelligence
 docker build -f docker/backend.Dockerfile -t mcf-backend .
 ```
 
+Create an env file for secrets (keeps credentials out of `docker inspect` and
+process listings):
+
+```bash
+sudo mkdir -p /opt/mcf
+sudo tee /opt/mcf/.env > /dev/null <<'EOF'
+DATABASE_URL=postgresql://<neon-dsn>
+MCF_SEARCH_BACKEND=pgvector
+MCF_LEAN_HOSTED=1
+MCF_EMBEDDING_BACKEND=onnx
+MCF_CORS_ORIGINS=https://<your-frontend-origin>
+EOF
+sudo chmod 600 /opt/mcf/.env
+```
+
 Run the API against Neon:
 
 ```bash
 docker run -d \
   --name mcf-api \
   --restart unless-stopped \
+  --env-file /opt/mcf/.env \
+  --memory 3g \
+  --log-opt max-size=10m \
+  --log-opt max-file=5 \
   -p 8000:8000 \
-  -e DATABASE_URL='postgresql://<neon-dsn>' \
-  -e MCF_SEARCH_BACKEND='pgvector' \
-  -e MCF_LEAN_HOSTED='1' \
-  -e MCF_EMBEDDING_BACKEND='onnx' \
-  -e MCF_CORS_ORIGINS='https://<your-frontend-origin>' \
   mcf-backend \
   uvicorn src.api.app:app --host 0.0.0.0 --port 8000 --workers 1
 ```
@@ -194,18 +213,57 @@ Notes:
 - `MCF_ONNX_MODEL_DIR` is not required when you use the bundled backend image
 - keep `--workers 1` unless you have measured memory and CPU headroom
 - do not mount FAISS indexes on Oracle; hosted search should use `pgvector`
+- `--memory 3g` matches the resource limits in `docker-compose.prod.yml`
+- `--log-opt` prevents unbounded log growth on the small VM
+- the Dockerfile does not set a default `MCF_CORS_ORIGINS` — you must set it in
+  the env file or the API will reject cross-origin requests
 
-If you want HTTPS, put Nginx or Caddy in front of the container and proxy to
-`127.0.0.1:8000`.
+## 9. Set up HTTPS with Caddy
 
-## 9. Smoke-test the hosted API
+Install Caddy on the Oracle VM for automatic TLS via Let's Encrypt:
+
+```bash
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | \
+  sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
+  sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt-get update
+sudo apt-get install -y caddy
+```
+
+Create a Caddyfile:
+
+```bash
+sudo tee /etc/caddy/Caddyfile > /dev/null <<'EOF'
+api.yourdomain.com {
+    reverse_proxy 127.0.0.1:8000
+}
+EOF
+sudo systemctl reload caddy
+```
+
+Caddy automatically provisions and renews Let's Encrypt certificates. Point
+your DNS A record to the Oracle VM's public IP before starting Caddy.
+
+Once Caddy is active, close port `8000` in the Oracle security list — all
+traffic should go through ports 80/443.
+
+Update `MCF_CORS_ORIGINS` in `/opt/mcf/.env` to use your HTTPS domain, then
+restart the API container:
+
+```bash
+docker restart mcf-api
+```
+
+## 10. Smoke-test the hosted API
 
 From the Oracle VM or your workstation:
 
 ```bash
-curl http://<oracle-ip>:8000/health
-curl http://<oracle-ip>:8000/docs
-curl -X POST http://<oracle-ip>:8000/api/search \
+curl https://api.yourdomain.com/health
+curl https://api.yourdomain.com/docs
+curl -X POST https://api.yourdomain.com/api/search \
   -H 'Content-Type: application/json' \
   -d '{"query":"data analyst","limit":5}'
 ```
@@ -216,7 +274,23 @@ Expected results:
 - `/docs` loads the FastAPI OpenAPI UI
 - `/api/search` returns recent retained jobs from the hosted slice
 
-## 10. Ongoing operations
+## 11. Frontend deployment
+
+The frontend is a static React SPA that can be deployed independently of the
+API backend. Options:
+
+- **Static hosting** (Vercel, Netlify, Cloudflare Pages): push the
+  `src/frontend/` directory and set the build command to `npm run build`. Set
+  the API base URL via environment variable to point at the Oracle API.
+- **Oracle VM co-hosting**: build and run the frontend Docker image on the same
+  VM using `docker/frontend.Dockerfile`. Add a second Caddy site block to serve
+  the frontend on a separate subdomain.
+
+Either way, the frontend makes API calls to `/api/*` which must resolve to the
+backend. On static hosts, configure a rewrite/proxy rule. On Oracle co-hosting,
+update `docker/nginx.conf` to proxy to the backend container name or IP.
+
+## 12. Ongoing operations
 
 - Continue scraping the full archive locally. Local Postgres remains the system
   of record.
@@ -225,7 +299,7 @@ Expected results:
   close to the Free storage cap, reduce retention before the database fills up.
 - Keep Oracle focused on the API only. Do not run the scraper daemon there.
 
-## 11. Rollback
+## 13. Rollback
 
 If the hosted deployment misbehaves:
 
@@ -236,7 +310,6 @@ If the hosted deployment misbehaves:
 poetry run python -m src.cli pg-seed-hosted \
   --source "$LOCAL_DATABASE_URL" \
   --target "$NEON_DATABASE_URL" \
-  --min-posted-date 2026-01-01 \
   --max-age-days 90
 ```
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -2731,10 +2731,10 @@ def migrate_postgres(
 def seed_hosted(
     source: str = typer.Option(..., "--source", help="Source PostgreSQL DSN"),
     target: str = typer.Option(..., "--target", help="Target PostgreSQL DSN"),
-    min_posted_date: str = typer.Option(
-        DEFAULT_HOSTED_SLICE_POLICY.min_posted_date.isoformat(),
+    min_posted_date: Optional[str] = typer.Option(
+        None,
         "--min-posted-date",
-        help="Minimum posted date to retain in the hosted slice",
+        help="Minimum posted date to retain (default: Jan 1 of current year)",
     ),
     max_age_days: int = typer.Option(
         DEFAULT_HOSTED_SLICE_POLICY.max_age_days,
@@ -2744,7 +2744,7 @@ def seed_hosted(
 ) -> None:
     """Seed a lean hosted slice from local Postgres."""
     policy = HostedSlicePolicy(
-        min_posted_date=date.fromisoformat(min_posted_date),
+        min_posted_date=date.fromisoformat(min_posted_date) if min_posted_date else None,
         max_age_days=max_age_days,
     )
     result = seed_hosted_slice_from_postgres(source_dsn=source, target_dsn=target, policy=policy)
@@ -2754,10 +2754,10 @@ def seed_hosted(
 @app.command(name="pg-purge-hosted")
 def purge_hosted(
     target: str = typer.Option(..., "--target", help="Target PostgreSQL DSN"),
-    min_posted_date: str = typer.Option(
-        DEFAULT_HOSTED_SLICE_POLICY.min_posted_date.isoformat(),
+    min_posted_date: Optional[str] = typer.Option(
+        None,
         "--min-posted-date",
-        help="Minimum posted date to retain in the hosted slice",
+        help="Minimum posted date to retain (default: Jan 1 of current year)",
     ),
     max_age_days: int = typer.Option(
         DEFAULT_HOSTED_SLICE_POLICY.max_age_days,
@@ -2767,7 +2767,7 @@ def purge_hosted(
 ) -> None:
     """Purge a hosted slice down to the lean Neon policy."""
     policy = HostedSlicePolicy(
-        min_posted_date=date.fromisoformat(min_posted_date),
+        min_posted_date=date.fromisoformat(min_posted_date) if min_posted_date else None,
         max_age_days=max_age_days,
     )
     result = purge_hosted_slice(target_dsn=target, policy=policy)

--- a/src/mcf/hosted_slice.py
+++ b/src/mcf/hosted_slice.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
-
 HOSTED_MAX_AGE_DAYS = 90
 
 

--- a/src/mcf/hosted_slice.py
+++ b/src/mcf/hosted_slice.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
-HOSTED_MIN_YEAR_DATE = date(2026, 1, 1)
+
+HOSTED_MIN_YEAR_DATE = date(date.today().year, 1, 1)
 HOSTED_MAX_AGE_DAYS = 90
 
 

--- a/src/mcf/hosted_slice.py
+++ b/src/mcf/hosted_slice.py
@@ -8,20 +8,20 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 
 
-HOSTED_MIN_YEAR_DATE = date(date.today().year, 1, 1)
 HOSTED_MAX_AGE_DAYS = 90
 
 
 @dataclass(frozen=True)
 class HostedSlicePolicy:
-    min_posted_date: date = HOSTED_MIN_YEAR_DATE
+    min_posted_date: date | None = None
     max_age_days: int = HOSTED_MAX_AGE_DAYS
     store_job_embeddings_only: bool = True
 
     def cutoff_date(self, today: date | None = None) -> date:
         current = today or date.today()
+        year_floor = self.min_posted_date or date(current.year, 1, 1)
         rolling_cutoff = current - timedelta(days=self.max_age_days)
-        return max(self.min_posted_date, rolling_cutoff)
+        return max(year_floor, rolling_cutoff)
 
     def include_posted_date(self, posted_date: date | None, today: date | None = None) -> bool:
         if posted_date is None:

--- a/src/mcf/postgres_migration.py
+++ b/src/mcf/postgres_migration.py
@@ -576,7 +576,7 @@ def seed_hosted_slice_from_postgres(
     source = PostgresDatabase(source_dsn, read_only=True, ensure_schema=False)
     target = PostgresDatabase(target_dsn, read_only=False, ensure_schema=True)
     cutoff = policy.cutoff_date()
-    hosted_year = policy.min_posted_date.year
+    hosted_year = policy.min_posted_date.year if policy.min_posted_date else date.today().year
     _truncate_postgres_target(target)
 
     with source._connection() as source_conn, target._connection() as target_conn:
@@ -687,7 +687,7 @@ def purge_hosted_slice(*, target_dsn: str, policy: HostedSlicePolicy) -> dict[st
     """
     target = PostgresDatabase(target_dsn, read_only=False, ensure_schema=True)
     cutoff = policy.cutoff_date()
-    hosted_year = policy.min_posted_date.year
+    hosted_year = policy.min_posted_date.year if policy.min_posted_date else date.today().year
     with target._connection() as conn:
         company_deleted = conn.execute(
             "DELETE FROM embeddings WHERE entity_type IN ('skill', 'company') RETURNING 1"


### PR DESCRIPTION
## Summary

- **Security**: Remove fail-open `MCF_CORS_ORIGINS=*` Dockerfile default, switch to `--env-file` for secret management (DSN no longer in `docker inspect`), add Caddy HTTPS setup to deploy guide
- **Reliability**: Bump healthcheck `start-period` to 120s, add `--memory 3g` and `--log-opt` to `docker run`, add failure notification step to refresh workflow, conditional torch install saves ~2GB on warm CI runs
- **Maintainability**: Make hosted slice year dynamic (`date.today().year` in Python, `$(date +%Y)` in workflow) so no manual updates needed on year rollover. Document frontend deployment options. Clarify homelab-only scope of `docker-compose.prod.yml`

## Files changed

| File | Change |
|------|--------|
| `docker/backend.Dockerfile` | Remove CORS default, bump healthcheck start-period |
| `.github/workflows/neon-hosted-refresh.yml` | Dynamic year, conditional torch, failure notification, shorter timeout |
| `docs/neon-oracle-hosted-deploy.md` | TLS section, env-file, log-opt, memory limit, frontend docs, dynamic year |
| `src/mcf/hosted_slice.py` | Dynamic year for min date constant |
| `docker-compose.prod.yml` | Clarifying comment |

## Test plan

- [ ] `poetry run python -c "from src.mcf.hosted_slice import DEFAULT_HOSTED_SLICE_POLICY; print(DEFAULT_HOSTED_SLICE_POLICY.min_posted_date)"` prints `2026-01-01` (current year)
- [ ] Workflow YAML validates: `python -c "import yaml; yaml.safe_load(open('.github/workflows/neon-hosted-refresh.yml'))"`
- [ ] `docker build -f docker/backend.Dockerfile .` builds successfully without CORS default
- [ ] Deploy guide reads coherently end-to-end (steps 1-13, no broken references)
- [ ] Manual dispatch of neon-hosted-refresh workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/jobs-intelligence/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPS deployment guidance with Caddy and frontend SPA deployment notes
  * Historical scraping now uses a runtime YEAR value

* **Bug Fixes**
  * Removed overly permissive CORS setting
  * Increased container healthcheck startup window for cold-start reliability
  * Hosted retention cutoff now uses a current-year floor plus a 90-day constraint

* **Documentation**
  * Switched docs/examples to dynamic year-based retention and clarified hosted vs. oracle deployment paths
  * Updated runtime guidance: env-file usage, memory/logging, and CLI default behavior for min-posted-date

* **Chores**
  * Optimized CI timeout, conditional dependency install on cache misses, and added failure-only reporting/annotations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->