### PR TITLE
Distinguish unreachable database from busy database in daemon start

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1228,7 +1228,14 @@ def daemon_cmd(
             raise typer.Exit(1)
         except DaemonError as e:
             console.print(f"[red]{e}[/red]")
-            console.print("Stop the other scrape process before starting the daemon.")
+            message = str(e)
+            if "busy" in message.lower():
+                console.print("Stop the other scrape process before starting the daemon.")
+            elif "unavailable" in message.lower():
+                console.print(
+                    "Check that the database server is running and reachable "
+                    "at the configured DSN."
+                )
             raise typer.Exit(1)
 
     elif action == "stop":

--- a/src/mcf/daemon.py
+++ b/src/mcf/daemon.py
@@ -207,7 +207,15 @@ class ScraperDaemon:
         if self.is_running():
             pid = self.get_pid()
             raise DaemonAlreadyRunning(f"Daemon already running with PID {pid}")
-        if not self.db.can_acquire_write_lock(db_path):
+        try:
+            writable = self.db.can_acquire_write_lock(db_path)
+        except Exception as exc:
+            # Connection refused, auth failure, missing database, etc. The
+            # message from psycopg / sqlite3 already names the real problem
+            # (e.g. "connection refused on port 55432"), so surface it as-is
+            # instead of claiming another process is writing.
+            raise DaemonError(f"Database unavailable: {exc}") from exc
+        if not writable:
             raise DaemonError("Database is busy: another process is writing to it")
 
         # Build command for the worker subprocess

--- a/src/mcf/pg_database.py
+++ b/src/mcf/pg_database.py
@@ -384,12 +384,15 @@ class PostgresDatabase:
     @staticmethod
     def can_acquire_write_lock(db_path: str, timeout_ms: int = 1000) -> bool:
         if db_path.strip().lower().startswith(("postgres://", "postgresql://")):
-            try:
-                db = PostgresDatabase(db_path, read_only=False, ensure_schema=False)
-                with db._connection():
-                    return True
-            except Exception:
-                return False
+            # Postgres permits concurrent writers, so "acquiring a write lock" only
+            # means verifying we can open a writable connection. We deliberately let
+            # connection, authentication, and schema errors propagate rather than
+            # squash them into False — callers need to distinguish "server is
+            # unreachable" from "another process holds the lock" to give users a
+            # useful error message.
+            db = PostgresDatabase(db_path, read_only=False, ensure_schema=False)
+            with db._connection():
+                return True
         return MCFDatabase.can_acquire_write_lock(db_path, timeout_ms=timeout_ms)
 
     def _save_to_history(self, conn: Any, existing: dict[str, Any]) -> None:

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -112,6 +112,41 @@ def test_daemon_start_fails_cleanly_when_database_is_busy(monkeypatch, temp_dir:
 
     assert result.exit_code == 1
     assert "Database is busy" in result.stdout
+    assert "Stop the other scrape process" in result.stdout
+
+
+def test_daemon_start_surfaces_unreachable_database(monkeypatch, temp_dir: Path):
+    """Start should distinguish 'server down' from 'another writer' so users
+    don't chase phantom processes when the real problem is connectivity."""
+    db_path = temp_dir / "test.db"
+
+    def fake_open_database(path: str | None, *, read_only: bool = False, ensure_schema: bool = True):
+        return object()
+
+    class FakeDaemon:
+        def __init__(self, db):
+            self.db = db
+
+        def start(self, **kwargs):
+            raise cli.DaemonError(
+                "Database unavailable: connection to server at '127.0.0.1', "
+                "port 55432 failed: Connection refused"
+            )
+
+    monkeypatch.setattr(cli, "_open_database", fake_open_database)
+    monkeypatch.setattr(cli, "ScraperDaemon", FakeDaemon)
+
+    result = runner.invoke(
+        cli.app,
+        ["daemon", "start", "--year", "2022", "--db", str(db_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Database unavailable" in result.stdout
+    assert "Connection refused" in result.stdout
+    # The "stop the other process" hint would be misleading here.
+    assert "Stop the other scrape process" not in result.stdout
+    assert "database server is running and reachable" in result.stdout
 
 
 def test_daemon_start_uses_persisted_database_target_when_db_is_omitted(monkeypatch, temp_dir: Path):


### PR DESCRIPTION
## Summary
- `can_acquire_write_lock` for Postgres no longer swallows every exception as "busy" — connection/auth errors propagate with their original message
- Daemon start distinguishes lock contention (`"Database is busy"`) from unavailability (`"Database unavailable: <cause>"`)
- CLI only suggests "stop the other scrape process" for real lock contention; unavailability gets a "check that the server is running" hint

## Why
While trying to start the daemon against local Postgres, the server happened to be down. The user saw `Database is busy: another process is writing to it` and went hunting for a phantom writer. The real error — `connection refused on port 55432` — was hidden inside a generic `except Exception: return False`. Postgres permits concurrent writers anyway, so "can't connect" for Postgres never means "busy".

## Test plan
- [x] `pytest tests/test_cli_daemon.py tests/test_daemon.py tests/test_database.py` — 63 passed
- [x] New test `test_daemon_start_surfaces_unreachable_database` asserts the real psycopg message reaches the user and the misleading "stop the other process" hint is suppressed
- [x] Existing `test_daemon_start_fails_cleanly_when_database_is_busy` still passes with the lock-contention hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xang1234/jobs-intelligence/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Daemon startup now provides context-specific error guidance
  * Busy database errors prompt users to stop competing processes
  * Unavailable database errors prompt users to verify server connectivity
  * Fixed database connection errors being incorrectly categorized as lock conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->