### PR TITLE
[codex] Improve hosted Match Lab insights and cache replays

### DIFF
--- a/deploy/huggingface-space/Dockerfile
+++ b/deploy/huggingface-space/Dockerfile
@@ -2,11 +2,13 @@
 
 ARG SOURCE_REPO=https://github.com/xang1234/jobs-intelligence.git
 ARG SOURCE_REF=master
+ARG SOURCE_VERSION=dev
 
 FROM python:3.11-slim AS builder
 
 ARG SOURCE_REPO
 ARG SOURCE_REF
+ARG SOURCE_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc g++ git \
@@ -15,7 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir poetry==1.8.5
 
 WORKDIR /build
-RUN git clone --depth 1 --branch "$SOURCE_REF" "$SOURCE_REPO" app
+RUN echo "Building $SOURCE_REPO@$SOURCE_REF ($SOURCE_VERSION)" \
+    && git clone --depth 1 --branch "$SOURCE_REF" "$SOURCE_REPO" app
 
 WORKDIR /build/app
 RUN poetry export -f requirements.txt --without-hashes --without dev --with ml -o requirements.txt

--- a/deploy/huggingface-space/README.md
+++ b/deploy/huggingface-space/README.md
@@ -31,4 +31,5 @@ MCF_CORS_ORIGINS=https://jobs-intelligence.pages.dev,https://jobs.deepgradient.u
 MCF_RATE_LIMIT_RPM=100
 SOURCE_REPO=https://github.com/xang1234/jobs-intelligence.git
 SOURCE_REF=master
+SOURCE_VERSION=<git-sha-or-cache-buster>
 ```

--- a/docs/neon-oracle-hosted-deploy.md
+++ b/docs/neon-oracle-hosted-deploy.md
@@ -187,7 +187,11 @@ MCF_CORS_ORIGINS=https://jobs-intelligence.pages.dev,https://jobs.deepgradient.u
 MCF_RATE_LIMIT_RPM=100
 SOURCE_REPO=https://github.com/xang1234/jobs-intelligence.git
 SOURCE_REF=master
+SOURCE_VERSION=<git-sha-or-cache-buster>
 ```
+
+`scripts/deploy_huggingface_space.py` sets `SOURCE_VERSION` from the local git
+revision by default so Docker rebuilds the repo clone layer when the ref moves.
 
 Deploy with:
 

--- a/scripts/deploy_huggingface_space.py
+++ b/scripts/deploy_huggingface_space.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 from pathlib import Path
 
 from huggingface_hub import HfApi
-
 
 DEFAULT_REPO_ID = "xang1234/jobs-intelligence-api"
 DEFAULT_SOURCE_REF = "master"
@@ -48,12 +48,30 @@ def require_env(name: str) -> str:
     return value
 
 
+def resolve_source_version(root: Path, source_ref: str) -> str:
+    """Resolve a local git ref for Docker cache busting."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--verify", source_ref],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return source_ref
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Deploy the Hugging Face Space backend")
     parser.add_argument("--env-file", default="/tmp/mcf-deploy.env", help="Path to deploy env file")
     parser.add_argument("--repo-id", default=DEFAULT_REPO_ID, help="Space repo ID")
     parser.add_argument("--source-ref", default=DEFAULT_SOURCE_REF, help="Git ref cloned during Space build")
     parser.add_argument("--source-repo", default=DEFAULT_SOURCE_REPO, help="Git source repo cloned during Space build")
+    parser.add_argument(
+        "--source-version",
+        default=None,
+        help="Cache-busting source version passed to the Docker build. Defaults to the local git revision.",
+    )
     parser.add_argument("--cors-origins", default=DEFAULT_CORS_ORIGINS, help="Comma-separated CORS origins")
     args = parser.parse_args()
 
@@ -64,6 +82,7 @@ def main() -> None:
 
     root = Path(__file__).resolve().parents[1]
     space_dir = root / "deploy" / "huggingface-space"
+    source_version = args.source_version or resolve_source_version(root, args.source_ref)
 
     api = HfApi(token=token)
     api.create_repo(
@@ -83,6 +102,7 @@ def main() -> None:
         "MCF_RATE_LIMIT_RPM": "100",
         "SOURCE_REPO": args.source_repo,
         "SOURCE_REF": args.source_ref,
+        "SOURCE_VERSION": source_version,
     }
     for key, value in variables.items():
         api.add_space_variable(args.repo_id, key, value, token=token)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -87,6 +87,8 @@ _search_engine: Optional[SemanticSearchEngine] = None
 # concurrent mutation of TTLCache and other non-thread-safe state.
 # FAISS/numpy still release the GIL, so CPU work parallelizes natively.
 _engine_executor = ThreadPoolExecutor(max_workers=1)
+MATCH_LAB_RESPONSE_CACHE_TTL_SECONDS = 300
+MATCH_LAB_RESPONSE_CACHE_MAX_ENTRIES = 128
 
 
 class _CareerDeltaTaxonomyHelper:
@@ -130,6 +132,26 @@ def _get_career_delta_detail_cache(
     cache = TTLCache(maxsize=max_entries, ttl=ttl_seconds)
     setattr(engine, "_career_delta_detail_cache", cache)
     return cache
+
+
+def _get_match_lab_response_cache(engine: SemanticSearchEngine, name: str) -> TTLCache:
+    """Lazily construct a short-lived response cache for expensive Match Lab calls."""
+    attr = f"_match_lab_{name}_response_cache"
+    cached = getattr(engine, attr, None)
+    if isinstance(cached, TTLCache):
+        return cached
+
+    cache = TTLCache(
+        maxsize=MATCH_LAB_RESPONSE_CACHE_MAX_ENTRIES,
+        ttl=MATCH_LAB_RESPONSE_CACHE_TTL_SECONDS,
+    )
+    setattr(engine, attr, cache)
+    return cache
+
+
+def _request_cache_key(prefix: str, request) -> str:
+    """Build a stable cache key for exact API request replays."""
+    return f"{prefix}:{request.model_dump_json()}"
 
 
 def _filter_detail_summaries(
@@ -694,6 +716,12 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> ProfileMatchResponse:
         """Match a pasted candidate profile or resume text to jobs."""
+        cache = _get_match_lab_response_cache(engine, "profile")
+        cache_key = _request_cache_key("profile", request)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached.model_copy(deep=True)
+
         loop = asyncio.get_running_loop()
         raw = await loop.run_in_executor(
             None,
@@ -707,13 +735,15 @@ def _register_routes(app: FastAPI) -> None:
                 limit=request.limit,
             ),
         )
-        return ProfileMatchResponse(
+        response = ProfileMatchResponse(
             results=[JobResult.from_internal(item) for item in raw["results"]],
             extracted_skills=raw["extracted_skills"],
             total_candidates=raw["total_candidates"],
             search_time_ms=raw["search_time_ms"],
             degraded=raw["degraded"],
         )
+        cache[cache_key] = response
+        return response
 
     @app.post("/api/career-delta", response_model=CareerDeltaAnalysisResponse)
     async def career_delta_analysis(
@@ -721,6 +751,12 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> CareerDeltaAnalysisResponse:
         """Run career-delta analysis through the serialized backend executor."""
+        cache = _get_match_lab_response_cache(engine, "career_delta")
+        cache_key = _request_cache_key("career_delta", request)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached.model_copy(deep=True)
+
         loop = asyncio.get_running_loop()
         internal_req = request.to_internal()
         allowed_delta_types = tuple(item.value for item in request.selected_delta_types())
@@ -740,11 +776,13 @@ def _register_routes(app: FastAPI) -> None:
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         elapsed_ms = round((loop.time() - started) * 1000, 3)
-        return CareerDeltaAnalysisResponse.from_internal(
+        response = CareerDeltaAnalysisResponse.from_internal(
             internal_resp,
             allowed_delta_types=request.selected_delta_types(),
             analysis_time_ms=elapsed_ms,
         )
+        cache[cache_key] = response
+        return response
 
     @app.get("/api/career-delta/{scenario_id}/detail", response_model=CareerDeltaScenarioDetail)
     async def career_delta_detail(

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,18 +1,19 @@
-import { useCallback, useEffect, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
 import { NavLink, Route, Routes, useLocation } from 'react-router-dom'
 import { Bars3Icon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
-import MatchLabPage from '@/pages/MatchLabPage'
-import OverviewPage from '@/pages/OverviewPage'
-import SearchPage from '@/pages/SearchPage'
-import TrendsPage from '@/pages/TrendsPage'
 import CommandPalette from '@/components/shell/CommandPalette'
 import MobileNav from '@/components/shell/MobileNav'
 import ThemeToggle from '@/components/shell/ThemeToggle'
 import TopProgressBar from '@/components/shell/TopProgressBar'
-import { IconButton, Kbd } from '@/components/ui'
+import { IconButton, Kbd, Spinner } from '@/components/ui'
 import { useHotkeys } from '@/hooks/useHotkeys'
 
 type NavItem = { to: string; label: string; end?: boolean }
+
+const OverviewPage = lazy(() => import('@/pages/OverviewPage'))
+const TrendsPage = lazy(() => import('@/pages/TrendsPage'))
+const MatchLabPage = lazy(() => import('@/pages/MatchLabPage'))
+const SearchPage = lazy(() => import('@/pages/SearchPage'))
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { to: '/', label: 'Overview', end: true },
@@ -20,6 +21,14 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { to: '/match-lab', label: 'Match Lab' },
   { to: '/search', label: 'Search & Similarity' },
 ]
+
+function RouteLoading() {
+  return (
+    <div className="flex min-h-[420px] items-center justify-center">
+      <Spinner size="lg" label="Loading page" className="text-[color:var(--brand)]" />
+    </div>
+  )
+}
 
 export default function App() {
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -129,12 +138,14 @@ export default function App() {
         </header>
 
         <main className="py-8">
-          <Routes>
-            <Route path="/" element={<OverviewPage />} />
-            <Route path="/trends" element={<TrendsPage />} />
-            <Route path="/match-lab" element={<MatchLabPage />} />
-            <Route path="/search" element={<SearchPage />} />
-          </Routes>
+          <Suspense fallback={<RouteLoading />}>
+            <Routes>
+              <Route path="/" element={<OverviewPage />} />
+              <Route path="/trends" element={<TrendsPage />} />
+              <Route path="/match-lab" element={<MatchLabPage />} />
+              <Route path="/search" element={<SearchPage />} />
+            </Routes>
+          </Suspense>
         </main>
       </div>
 

--- a/src/frontend/src/pages/MatchLabPage.tsx
+++ b/src/frontend/src/pages/MatchLabPage.tsx
@@ -958,6 +958,7 @@ export default function MatchLabPage() {
   const inputsReady = inputs.profileText.trim().length >= 20
   const anyPending = matchMutation.isPending || whatIfMutation.isPending
   const whatIfHasAttempted = whatIfMutation.data !== undefined || whatIfMutation.error !== null
+  const profileMatchExtractedSkills = matchMutation.data?.extracted_skills ?? []
 
   const runCurrentMatch = (nextInputs = inputs) => {
     setActiveTab('match')
@@ -1214,8 +1215,8 @@ export default function MatchLabPage() {
                 <div className="mt-4">
                   <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--ink-subtle)]">Extracted skills</p>
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {matchMutation.data?.extracted_skills.length ? (
-                      matchMutation.data.extracted_skills.map((skill) => (
+                    {profileMatchExtractedSkills.length ? (
+                      profileMatchExtractedSkills.map((skill) => (
                         <span key={skill} className="rounded-full bg-[color:var(--surface)] px-3 py-1 text-xs font-medium text-[color:var(--ink-muted)]">
                           {skill}
                         </span>

--- a/src/mcf/career_delta_retrieval.py
+++ b/src/mcf/career_delta_retrieval.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from .career_delta import CareerDeltaCandidate, CareerDeltaCandidatePool, CareerDeltaRequest
+from .database import is_broad_singapore_region
 from .embeddings.models import SearchRequest
 from .embeddings.search_engine import SemanticSearchEngine
 from .industry_taxonomy import (
@@ -69,7 +70,11 @@ class SearchEngineCareerDeltaProvider:
             job = jobs.get(uuid)
             if not job:
                 continue
-            if request.location and job.get("region") != request.location:
+            if (
+                request.location
+                and not is_broad_singapore_region(request.location)
+                and job.get("region") != request.location
+            ):
                 continue
 
             title_match = bool(

--- a/src/mcf/database.py
+++ b/src/mcf/database.py
@@ -2341,9 +2341,7 @@ class MCFDatabase:
     def _latest_posted_date(self) -> Optional[date]:
         """Return the freshest posted date available in the jobs table."""
         with self._connection() as conn:
-            row = conn.execute(
-                "SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL"
-            ).fetchone()
+            row = conn.execute("SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL").fetchone()
         if not row:
             return None
         return coerce_posted_date(row["latest"])

--- a/src/mcf/database.py
+++ b/src/mcf/database.py
@@ -28,6 +28,43 @@ from .models import Job
 
 logger = logging.getLogger(__name__)
 
+REPRESENTATIVE_MONTH_MIN_JOBS = 10
+REPRESENTATIVE_MONTH_MIN_RATIO = 0.10
+
+
+def coerce_posted_date(value: Any) -> Optional[date]:
+    """Return a date object from SQLite strings or database-native date values."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if hasattr(value, "year") and hasattr(value, "month") and hasattr(value, "day"):
+        return date(int(value.year), int(value.month), int(value.day))
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def posted_month_key(value: Any) -> str:
+    """Return a YYYY-MM key from SQLite strings or database-native date values."""
+    posted = coerce_posted_date(value)
+    if posted is not None:
+        return posted.strftime("%Y-%m")
+    return str(value)[:7]
+
+
+def is_broad_singapore_region(region: str | None) -> bool:
+    """Treat Singapore-level filters as the whole local market, not a subregion."""
+    if not region:
+        return False
+    normalized = region.strip().lower().replace(".", "")
+    return normalized in {"singapore", "sg"}
+
+
 # SQL schema definitions
 SCHEMA_SQL = """
 -- Main jobs table: current state of each job
@@ -1006,7 +1043,7 @@ class MCFDatabase:
             conditions.append("employment_type = ?")
             params.append(employment_type)
 
-        if region:
+        if region and not is_broad_singapore_region(region):
             conditions.append("region = ?")
             params.append(region)
 
@@ -2293,13 +2330,59 @@ class MCFDatabase:
         return date(year, month, 1)
 
     @classmethod
-    def _month_labels(cls, months: int) -> list[str]:
+    def _month_labels(cls, months: int, anchor_date: date | None = None) -> list[str]:
         """Generate YYYY-MM labels from oldest to newest."""
-        start = date.today().replace(day=1)
+        start = (anchor_date or date.today()).replace(day=1)
         labels = []
         for offset in range(months - 1, -1, -1):
             labels.append(cls._subtract_months(start, offset).strftime("%Y-%m"))
         return labels
+
+    def _latest_posted_date(self) -> Optional[date]:
+        """Return the freshest posted date available in the jobs table."""
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL"
+            ).fetchone()
+        if not row:
+            return None
+        return coerce_posted_date(row["latest"])
+
+    @staticmethod
+    def _representative_anchor_date(month_rows: list[Any]) -> Optional[date]:
+        """Choose the latest month with enough volume to represent market trends."""
+        if not month_rows:
+            return None
+
+        max_count = max(int(row["job_count"]) for row in month_rows)
+        newest = coerce_posted_date(month_rows[0]["latest_posted_date"])
+        if max_count < REPRESENTATIVE_MONTH_MIN_JOBS:
+            return newest
+
+        representative_floor = max(
+            REPRESENTATIVE_MONTH_MIN_JOBS,
+            int(max_count * REPRESENTATIVE_MONTH_MIN_RATIO),
+        )
+        for row in month_rows:
+            if int(row["job_count"]) >= representative_floor:
+                return coerce_posted_date(row["latest_posted_date"])
+        return newest
+
+    def _trend_anchor_date(self) -> date:
+        """Anchor market windows to available data, falling back to today when empty."""
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT substr(posted_date, 1, 7) AS month_key,
+                       COUNT(*) AS job_count,
+                       MAX(posted_date) AS latest_posted_date
+                FROM jobs
+                WHERE posted_date IS NOT NULL
+                GROUP BY month_key
+                ORDER BY month_key DESC
+                """
+            ).fetchall()
+        return self._representative_anchor_date(rows) or date.today()
 
     @staticmethod
     def _median(values: list[int]) -> Optional[int]:
@@ -2371,7 +2454,7 @@ class MCFDatabase:
             conditions.append("employment_type = ?")
             params.append(employment_type)
 
-        if region:
+        if region and not is_broad_singapore_region(region):
             conditions.append("region = ?")
             params.append(region)
 
@@ -2393,9 +2476,11 @@ class MCFDatabase:
         keyword: str | None = None,
         company_exact: bool = False,
         skill: str | None = None,
+        anchor_date: date | None = None,
     ) -> list[sqlite3.Row]:
         """Fetch minimally shaped rows for time-series aggregation."""
-        start_month = self._subtract_months(date.today().replace(day=1), months - 1)
+        anchor = anchor_date or self._trend_anchor_date()
+        start_month = self._subtract_months(anchor.replace(day=1), months - 1)
         conditions = ["posted_date IS NOT NULL", "posted_date >= ?"]
         params: list[Any] = [start_month.isoformat()]
 
@@ -2426,23 +2511,41 @@ class MCFDatabase:
                 params,
             ).fetchall()
 
+    def fetch_recent_market_rows(self, start_month: date) -> list[sqlite3.Row]:
+        """Fetch recent rows used to build cached market aggregates."""
+        with self._connection() as conn:
+            return conn.execute(
+                """
+                SELECT posted_date, title, company_name, categories, skills,
+                       salary_annual_min, salary_annual_max, title_family, industry_bucket
+                FROM jobs
+                WHERE posted_date IS NOT NULL
+                  AND posted_date >= ?
+                ORDER BY posted_date ASC
+                """,
+                (start_month.isoformat(),),
+            ).fetchall()
+
     def _get_market_monthly_counts(
         self,
         months: int,
         company_name: str | None = None,
         employment_type: str | None = None,
         region: str | None = None,
+        anchor_date: date | None = None,
     ) -> dict[str, int]:
         """Get baseline monthly job counts for market share calculations."""
+        anchor = anchor_date or self._trend_anchor_date()
         rows = self._fetch_trend_rows(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
+            anchor_date=anchor,
         )
-        counts = {label: 0 for label in self._month_labels(months)}
+        counts = {label: 0 for label in self._month_labels(months, anchor)}
         for row in rows:
-            month = row["posted_date"][:7]
+            month = posted_month_key(row["posted_date"])
             if month in counts:
                 counts[month] += 1
         return counts
@@ -2452,9 +2555,10 @@ class MCFDatabase:
         rows: list[sqlite3.Row],
         months: int,
         market_counts: Optional[dict[str, int]] = None,
+        anchor_date: date | None = None,
     ) -> list[dict]:
         """Convert raw rows into a dense monthly trend series."""
-        labels = self._month_labels(months)
+        labels = self._month_labels(months, anchor_date or self._trend_anchor_date())
         points = {
             label: {
                 "month": label,
@@ -2468,7 +2572,7 @@ class MCFDatabase:
         salary_buckets: dict[str, list[int]] = {label: [] for label in labels}
 
         for row in rows:
-            month = row["posted_date"][:7]
+            month = posted_month_key(row["posted_date"])
             if month not in points:
                 continue
             points[month]["job_count"] += 1
@@ -2519,11 +2623,13 @@ class MCFDatabase:
         region: str | None = None,
     ) -> list[dict]:
         """Return monthly trend series for each requested skill."""
+        anchor = self._trend_anchor_date()
         market_counts = self._get_market_monthly_counts(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
+            anchor_date=anchor,
         )
         trends = []
         for skill in skills:
@@ -2533,8 +2639,9 @@ class MCFDatabase:
                 employment_type=employment_type,
                 region=region,
                 skill=skill,
+                anchor_date=anchor,
             )
-            series = self._rows_to_series(rows, months, market_counts)
+            series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
             trends.append(
                 {
                     "skill": skill,
@@ -2553,20 +2660,23 @@ class MCFDatabase:
         region: str | None = None,
     ) -> dict:
         """Return monthly trend data for a role/query string."""
+        anchor = self._trend_anchor_date()
         rows = self._fetch_trend_rows(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
             keyword=query,
+            anchor_date=anchor,
         )
         market_counts = self._get_market_monthly_counts(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
+            anchor_date=anchor,
         )
-        series = self._rows_to_series(rows, months, market_counts)
+        series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
         return {
             "query": query,
             "series": series,
@@ -2575,17 +2685,19 @@ class MCFDatabase:
 
     def get_company_trend(self, company_name: str, months: int = 12) -> dict:
         """Return hiring trend and skill mix for a single company."""
+        anchor = self._trend_anchor_date()
         rows = self._fetch_trend_rows(
             months=months,
             company_name=company_name,
             company_exact=True,
+            anchor_date=anchor,
         )
-        market_counts = self._get_market_monthly_counts(months=months)
-        series = self._rows_to_series(rows, months, market_counts)
+        market_counts = self._get_market_monthly_counts(months=months, anchor_date=anchor)
+        series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
 
-        skills_by_month: dict[str, Counter] = {label: Counter() for label in self._month_labels(months)}
+        skills_by_month: dict[str, Counter] = {label: Counter() for label in self._month_labels(months, anchor)}
         for row in rows:
-            month = row["posted_date"][:7]
+            month = posted_month_key(row["posted_date"])
             raw_skills = row["skills"] or ""
             for skill in [item.strip() for item in raw_skills.split(",") if item.strip()]:
                 skills_by_month[month][skill] += 1
@@ -2608,10 +2720,11 @@ class MCFDatabase:
 
     def get_overview(self, months: int = 12) -> dict:
         """Return summary cards and top movers for the homepage overview."""
-        labels = self._month_labels(months)
+        anchor = self._trend_anchor_date()
+        labels = self._month_labels(months, anchor)
         current_month = labels[-1]
         previous_month = labels[-2] if len(labels) > 1 else labels[-1]
-        rows = self._fetch_trend_rows(months=months)
+        rows = self._fetch_trend_rows(months=months, anchor_date=anchor)
 
         market_counts: Counter = Counter()
         market_salarys: dict[str, list[int]] = {label: [] for label in labels}
@@ -2624,7 +2737,7 @@ class MCFDatabase:
         salary_midpoints: list[int] = []
 
         for row in rows:
-            month = row["posted_date"][:7]
+            month = posted_month_key(row["posted_date"])
             if month not in market_salarys:
                 continue
 

--- a/src/mcf/embeddings/search_engine.py
+++ b/src/mcf/embeddings/search_engine.py
@@ -34,6 +34,7 @@ from typing import Optional
 import numpy as np
 from cachetools import TTLCache
 
+from ..database import is_broad_singapore_region
 from ..db_factory import open_database
 from .backends import DEFAULT_EMBEDDING_BACKEND, resolve_model_version
 from .faiss_backend import FAISSVectorBackend
@@ -600,7 +601,7 @@ class SemanticSearchEngine:
 
             if employment_type and job.get("employment_type") != employment_type:
                 continue
-            if region and job.get("region") != region:
+            if region and not is_broad_singapore_region(region) and job.get("region") != region:
                 continue
             if normalized_titles and not any(title in (job.get("title", "").lower()) for title in normalized_titles):
                 continue

--- a/src/mcf/market_stats.py
+++ b/src/mcf/market_stats.py
@@ -16,7 +16,7 @@ from datetime import date
 from typing import Callable, Optional
 
 from .career_delta import CareerDeltaRequest
-from .database import MCFDatabase
+from .database import MCFDatabase, posted_month_key
 from .industry_taxonomy import (
     IndustryClassification,
     classification_from_bucket,
@@ -145,8 +145,9 @@ class MarketStatsCache:
 
     def _build_snapshot(self) -> MarketStatsSnapshot:
         now = self.clock()
-        labels = self.db._month_labels(self.months)
-        rows = self._fetch_recent_rows()
+        anchor = self._latest_anchor_date()
+        labels = self.db._month_labels(self.months, anchor)
+        rows = self._fetch_recent_rows(anchor)
 
         market_counts: Counter[str] = Counter()
         skill_counts: dict[str, Counter[str]] = defaultdict(Counter)
@@ -173,7 +174,7 @@ class MarketStatsCache:
                 company_industries[company_name] = inferred
 
         for row in rows:
-            month = row["posted_date"][:7]
+            month = posted_month_key(row["posted_date"])
             if month not in labels:
                 continue
 
@@ -243,20 +244,19 @@ class MarketStatsCache:
         )
         return snapshot
 
-    def _fetch_recent_rows(self) -> list:
-        start_month = self.db._subtract_months(date.today().replace(day=1), self.months - 1)
-        with self.db._connection() as conn:
-            return conn.execute(
-                """
-                SELECT posted_date, title, company_name, categories, skills,
-                       salary_annual_min, salary_annual_max, title_family, industry_bucket
-                FROM jobs
-                WHERE posted_date IS NOT NULL
-                  AND posted_date >= ?
-                ORDER BY posted_date ASC
-                """,
-                (start_month.isoformat(),),
-            ).fetchall()
+    def _latest_anchor_date(self) -> date:
+        trend_anchor_date = getattr(self.db, "_trend_anchor_date", None)
+        if trend_anchor_date is not None:
+            return trend_anchor_date()
+        latest_posted_date = getattr(self.db, "_latest_posted_date", None)
+        if latest_posted_date is None:
+            return date.today()
+        return latest_posted_date() or date.today()
+
+    def _fetch_recent_rows(self, anchor_date: date | None = None) -> list:
+        anchor = anchor_date or self._latest_anchor_date()
+        start_month = self.db._subtract_months(anchor.replace(day=1), self.months - 1)
+        return self.db.fetch_recent_market_rows(start_month)
 
     def _build_aggregate(
         self,

--- a/src/mcf/pg_database.py
+++ b/src/mcf/pg_database.py
@@ -14,7 +14,7 @@ from typing import Any, Iterator, Optional
 
 import numpy as np
 
-from .database import MCFDatabase
+from .database import MCFDatabase, coerce_posted_date, is_broad_singapore_region, posted_month_key
 from .models import Job
 
 logger = logging.getLogger(__name__)
@@ -620,7 +620,7 @@ class PostgresDatabase:
         if employment_type:
             conditions.append("employment_type = %s")
             params.append(employment_type)
-        if region:
+        if region and not is_broad_singapore_region(region):
             conditions.append("region = %s")
             params.append(region)
 
@@ -1428,10 +1428,35 @@ class PostgresDatabase:
     _median = staticmethod(MCFDatabase._median)
     _salary_midpoint = staticmethod(MCFDatabase._salary_midpoint)
     _annotate_momentum = staticmethod(MCFDatabase._annotate_momentum)
+    _representative_anchor_date = staticmethod(MCFDatabase._representative_anchor_date)
 
     @classmethod
-    def _month_labels(cls, months: int) -> list[str]:
-        return MCFDatabase._month_labels(months)
+    def _month_labels(cls, months: int, anchor_date: date | None = None) -> list[str]:
+        return MCFDatabase._month_labels(months, anchor_date)
+
+    def _latest_posted_date(self) -> Optional[date]:
+        with self._connection() as conn:
+            row = conn.execute(
+                "SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL"
+            ).fetchone()
+        if not row:
+            return None
+        return coerce_posted_date(row["latest"])
+
+    def _trend_anchor_date(self) -> date:
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT TO_CHAR(posted_date, 'YYYY-MM') AS month_key,
+                       COUNT(*) AS job_count,
+                       MAX(posted_date) AS latest_posted_date
+                FROM jobs
+                WHERE posted_date IS NOT NULL
+                GROUP BY month_key
+                ORDER BY month_key DESC
+                """
+            ).fetchall()
+        return self._representative_anchor_date(rows) or date.today()
 
     def _build_filter_conditions(
         self,
@@ -1453,7 +1478,7 @@ class PostgresDatabase:
         if employment_type:
             conditions.append("employment_type = %s")
             params.append(employment_type)
-        if region:
+        if region and not is_broad_singapore_region(region):
             conditions.append("region = %s")
             params.append(region)
         if keyword:
@@ -1473,8 +1498,10 @@ class PostgresDatabase:
         keyword: str | None = None,
         company_exact: bool = False,
         skill: str | None = None,
+        anchor_date: date | None = None,
     ) -> list[dict]:
-        start_month = self._subtract_months(date.today().replace(day=1), months - 1)
+        anchor = anchor_date or self._trend_anchor_date()
+        start_month = self._subtract_months(anchor.replace(day=1), months - 1)
         conditions = ["posted_date IS NOT NULL", "posted_date >= %s"]
         params: list[Any] = [start_month]
         extra_conditions, extra_params = self._build_filter_conditions(
@@ -1501,23 +1528,39 @@ class PostgresDatabase:
                 params,
             ).fetchall()
 
+    def fetch_recent_market_rows(self, start_month: date) -> list[dict]:
+        with self._connection() as conn:
+            return conn.execute(
+                """
+                SELECT posted_date, title, company_name, categories, skills,
+                       salary_annual_min, salary_annual_max, title_family, industry_bucket
+                FROM jobs
+                WHERE posted_date IS NOT NULL
+                  AND posted_date >= %s
+                ORDER BY posted_date ASC
+                """,
+                (start_month,),
+            ).fetchall()
+
     def _get_market_monthly_counts(
         self,
         months: int,
         company_name: str | None = None,
         employment_type: str | None = None,
         region: str | None = None,
+        anchor_date: date | None = None,
     ) -> dict[str, int]:
+        anchor = anchor_date or self._trend_anchor_date()
         rows = self._fetch_trend_rows(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
+            anchor_date=anchor,
         )
-        counts = {label: 0 for label in self._month_labels(months)}
+        counts = {label: 0 for label in self._month_labels(months, anchor)}
         for row in rows:
-            posted = row["posted_date"]
-            month = posted.strftime("%Y-%m") if hasattr(posted, "strftime") else str(posted)[:7]
+            month = posted_month_key(row["posted_date"])
             if month in counts:
                 counts[month] += 1
         return counts
@@ -1527,8 +1570,9 @@ class PostgresDatabase:
         rows: list[dict],
         months: int,
         market_counts: Optional[dict[str, int]] = None,
+        anchor_date: date | None = None,
     ) -> list[dict]:
-        labels = self._month_labels(months)
+        labels = self._month_labels(months, anchor_date or self._trend_anchor_date())
         points = {
             label: {
                 "month": label,
@@ -1541,8 +1585,7 @@ class PostgresDatabase:
         }
         salary_buckets = {label: [] for label in labels}
         for row in rows:
-            posted = row["posted_date"]
-            month = posted.strftime("%Y-%m") if hasattr(posted, "strftime") else str(posted)[:7]
+            month = posted_month_key(row["posted_date"])
             if month not in points:
                 continue
             points[month]["job_count"] += 1
@@ -1589,7 +1632,14 @@ class PostgresDatabase:
         employment_type: str | None = None,
         region: str | None = None,
     ) -> list[dict]:
-        market_counts = self._get_market_monthly_counts(months, company_name, employment_type, region)
+        anchor = self._trend_anchor_date()
+        market_counts = self._get_market_monthly_counts(
+            months,
+            company_name,
+            employment_type,
+            region,
+            anchor_date=anchor,
+        )
         trends = []
         for skill in skills:
             rows = self._fetch_trend_rows(
@@ -1598,8 +1648,9 @@ class PostgresDatabase:
                 employment_type=employment_type,
                 region=region,
                 skill=skill,
+                anchor_date=anchor,
             )
-            series = self._rows_to_series(rows, months, market_counts)
+            series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
             trends.append({"skill": skill, "series": series, "latest": series[-1] if series else None})
         return trends
 
@@ -1611,19 +1662,38 @@ class PostgresDatabase:
         employment_type: str | None = None,
         region: str | None = None,
     ) -> dict:
-        rows = self._fetch_trend_rows(months, company_name, employment_type, region, keyword=query)
-        market_counts = self._get_market_monthly_counts(months, company_name, employment_type, region)
-        series = self._rows_to_series(rows, months, market_counts)
+        anchor = self._trend_anchor_date()
+        rows = self._fetch_trend_rows(
+            months,
+            company_name,
+            employment_type,
+            region,
+            keyword=query,
+            anchor_date=anchor,
+        )
+        market_counts = self._get_market_monthly_counts(
+            months,
+            company_name,
+            employment_type,
+            region,
+            anchor_date=anchor,
+        )
+        series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
         return {"query": query, "series": series, "latest": series[-1] if series else None}
 
     def get_company_trend(self, company_name: str, months: int = 12) -> dict:
-        rows = self._fetch_trend_rows(months=months, company_name=company_name, company_exact=True)
-        market_counts = self._get_market_monthly_counts(months=months)
-        series = self._rows_to_series(rows, months, market_counts)
-        skills_by_month: dict[str, Counter] = {label: Counter() for label in self._month_labels(months)}
+        anchor = self._trend_anchor_date()
+        rows = self._fetch_trend_rows(
+            months=months,
+            company_name=company_name,
+            company_exact=True,
+            anchor_date=anchor,
+        )
+        market_counts = self._get_market_monthly_counts(months=months, anchor_date=anchor)
+        series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
+        skills_by_month: dict[str, Counter] = {label: Counter() for label in self._month_labels(months, anchor)}
         for row in rows:
-            posted = row["posted_date"]
-            month = posted.strftime("%Y-%m") if hasattr(posted, "strftime") else str(posted)[:7]
+            month = posted_month_key(row["posted_date"])
             for skill in [item.strip() for item in (row["skills"] or "").split(",") if item.strip()]:
                 skills_by_month[month][skill] += 1
         top_skills_by_month = [
@@ -1638,10 +1708,11 @@ class PostgresDatabase:
         return {"company_name": company_name, "series": series, "top_skills_by_month": top_skills_by_month}
 
     def get_overview(self, months: int = 12) -> dict:
-        labels = self._month_labels(months)
+        anchor = self._trend_anchor_date()
+        labels = self._month_labels(months, anchor)
         current_month = labels[-1]
         previous_month = labels[-2] if len(labels) > 1 else labels[-1]
-        rows = self._fetch_trend_rows(months=months)
+        rows = self._fetch_trend_rows(months=months, anchor_date=anchor)
         market_counts: Counter = Counter()
         market_salarys: dict[str, list[int]] = {label: [] for label in labels}
         skill_counts: dict[str, Counter] = defaultdict(Counter)
@@ -1652,8 +1723,7 @@ class PostgresDatabase:
         unique_companies: set[str] = set()
         salary_midpoints: list[int] = []
         for row in rows:
-            posted = row["posted_date"]
-            month = posted.strftime("%Y-%m") if hasattr(posted, "strftime") else str(posted)[:7]
+            month = posted_month_key(row["posted_date"])
             if month not in market_salarys:
                 continue
             salary = self._salary_midpoint(row)

--- a/src/mcf/pg_database.py
+++ b/src/mcf/pg_database.py
@@ -1436,9 +1436,7 @@ class PostgresDatabase:
 
     def _latest_posted_date(self) -> Optional[date]:
         with self._connection() as conn:
-            row = conn.execute(
-                "SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL"
-            ).fetchone()
+            row = conn.execute("SELECT MAX(posted_date) AS latest FROM jobs WHERE posted_date IS NOT NULL").fetchone()
         if not row:
             return None
         return coerce_posted_date(row["latest"])

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -565,6 +565,21 @@ class TestMarketIntelligenceEndpoints:
         assert data["total_candidates"] == 24
         mock_engine.match_profile.assert_called_once()
 
+    def test_profile_match_caches_identical_requests(self, client, mock_engine):
+        payload = {
+            "profile_text": "Senior analytics leader with Python and SQL experience across ML platforms.",
+            "target_titles": ["Data Scientist"],
+            "salary_expectation_annual": 180000,
+        }
+
+        first = client.post("/api/match/profile", json=payload)
+        second = client.post("/api/match/profile", json=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine.match_profile.assert_called_once()
+
 
 class TestCareerDeltaEndpoint:
     def test_career_delta_analysis(self, client, mock_engine):
@@ -621,6 +636,36 @@ class TestCareerDeltaEndpoint:
         internal_req = mock_engine._career_delta_engine.analyze.call_args[0][0]
         assert internal_req.profile_text == "Senior data analyst with Python, SQL, and dashboarding experience."
         assert internal_req.limit == 6
+
+    def test_career_delta_analysis_caches_identical_requests(self, client, mock_engine):
+        mock_engine._career_delta_engine = MagicMock()
+        mock_engine._career_delta_engine.analyze.return_value = CareerDeltaResponse(
+            request=MagicMock(location="Singapore"),
+            baseline=BaselineMarketPosition(
+                position=MarketPosition.COMPETITIVE,
+                reachable_jobs=12,
+                total_candidates=30,
+                fit_median=0.61,
+                fit_p90=0.8,
+                salary_band=SalaryBand(min_annual=90000, median_annual=110000, max_annual=140000),
+            ),
+            summaries=(),
+            filtered_scenarios=(),
+            degraded=False,
+            thin_market=False,
+        )
+        payload = {
+            "profile_text": "Senior data analyst with Python, SQL, and dashboarding experience.",
+            "max_scenarios": 6,
+        }
+
+        first = client.post("/api/career-delta", json=payload)
+        second = client.post("/api/career-delta", json=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine._career_delta_engine.analyze.assert_called_once()
 
     def test_career_delta_analysis_surfaces_thin_market_and_degraded_flags(self, client, mock_engine):
         mock_engine._career_delta_engine = MagicMock()

--- a/tests/test_career_delta_retrieval.py
+++ b/tests/test_career_delta_retrieval.py
@@ -23,6 +23,7 @@ def _insert_job(
     posted_days_ago: int,
     salary_min: int,
     salary_max: int,
+    region: str = "Central",
 ) -> None:
     job = generate_test_job(
         title=title,
@@ -33,6 +34,8 @@ def _insert_job(
     )
     job.categories = [Category(category=category) for category in categories]
     job.metadata = generate_metadata(posted_days_ago=posted_days_ago)
+    if job.address:
+        job.address.region = region
     db.upsert_job(job)
 
 
@@ -121,6 +124,38 @@ def test_provider_keeps_pool_broad_even_with_target_titles(temp_dir, empty_db):
     assert "Analytics Engineer" in titles
     assert titles["Senior Data Scientist"] is True
     assert titles["Analytics Engineer"] is False
+
+
+def test_provider_treats_singapore_location_as_broad_market_region(temp_dir, empty_db):
+    _insert_job(
+        empty_db,
+        title="Senior Data Scientist",
+        company_name="Hosted Rows Ltd",
+        skills=["Python", "SQL", "Machine Learning"],
+        categories=["Data Science"],
+        posted_days_ago=2,
+        salary_min=12000,
+        salary_max=16000,
+        region="",
+    )
+
+    engine = SemanticSearchEngine(
+        db_path=str(empty_db.db_path),
+        index_dir=temp_dir / "missing-indexes",
+    )
+    provider = SearchEngineCareerDeltaProvider(engine, minimum_pool_size=10)
+
+    pool = provider.build_candidate_pool(
+        CareerDeltaRequest(
+            profile_text="Senior data scientist with Python, SQL, and machine learning experience.",
+            target_titles=("Data Scientist",),
+            location="Singapore",
+            limit=5,
+        )
+    )
+
+    assert pool.candidates
+    assert pool.candidates[0].title == "Senior Data Scientist"
 
 
 def test_provider_records_job_side_gap_skills_for_addition_scenarios(temp_dir, empty_db):

--- a/tests/test_market_intelligence.py
+++ b/tests/test_market_intelligence.py
@@ -143,6 +143,67 @@ def test_overview_avoids_nested_trend_queries(empty_db: MCFDatabase):
     assert overview["rising_companies"]
 
 
+def test_overview_anchors_current_month_to_latest_available_job(empty_db: MCFDatabase):
+    _insert_job(
+        empty_db,
+        title="Data Scientist",
+        company_name="Stale But Freshest",
+        skills=["Python", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(1, day=20),
+        salary_min=10000,
+        salary_max=14000,
+    )
+
+    overview = empty_db.get_overview(months=2)
+
+    assert overview["headline_metrics"]["current_month_jobs"] == 1
+    assert overview["market_insights"][0]["value"] == 1
+
+
+def test_overview_anchors_to_representative_month_when_latest_month_is_sparse(empty_db: MCFDatabase):
+    for idx in range(12):
+        _insert_job(
+            empty_db,
+            title=f"Data Scientist {idx}",
+            company_name=f"Representative {idx}",
+            skills=["Python", "SQL"],
+            posted_days_ago=posted_days_ago_for_month_offset(1, day=10 + (idx % 5)),
+            salary_min=10000,
+            salary_max=14000,
+        )
+    _insert_job(
+        empty_db,
+        title="Data Scientist Sparse",
+        company_name="Sparse Latest",
+        skills=["Python", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=1),
+        salary_min=10000,
+        salary_max=14000,
+    )
+
+    overview = empty_db.get_overview(months=3)
+
+    assert overview["headline_metrics"]["current_month_jobs"] == 12
+    assert overview["market_insights"][0]["value"] == 12
+
+
+def test_search_jobs_treats_singapore_as_broad_market_region(empty_db: MCFDatabase):
+    _insert_job(
+        empty_db,
+        title="Data Scientist",
+        company_name="Hosted Rows Ltd",
+        skills=["Python", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=10),
+        salary_min=10000,
+        salary_max=14000,
+        region="",
+    )
+
+    results = empty_db.search_jobs(region="Singapore", limit=5)
+
+    assert [job["title"] for job in results] == ["Data Scientist"]
+
+
 def test_search_results_include_explanations(temp_dir: Path, empty_db: MCFDatabase):
     _insert_job(
         empty_db,
@@ -209,6 +270,34 @@ def test_profile_match_returns_fit_breakdown(temp_dir: Path, empty_db: MCFDataba
     assert top.explanations.skill_overlap_score is not None
     assert top.explanations.overall_fit is not None
     assert "Python" in top.matched_skills
+
+
+def test_profile_match_treats_singapore_as_broad_market_region(temp_dir: Path, empty_db: MCFDatabase):
+    _insert_job(
+        empty_db,
+        title="Senior Data Scientist",
+        company_name="Hosted Rows Ltd",
+        skills=["Python", "SQL", "Machine Learning"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=12),
+        salary_min=12000,
+        salary_max=16000,
+        region="",
+    )
+
+    engine = SemanticSearchEngine(
+        db_path=str(empty_db.db_path),
+        index_dir=temp_dir / "missing-indexes",
+    )
+
+    result = engine.match_profile(
+        profile_text="Senior data scientist with Python, SQL, and machine learning experience.",
+        target_titles=["Data Scientist"],
+        region="Singapore",
+        limit=5,
+    )
+
+    assert result["results"]
+    assert result["results"][0].title == "Senior Data Scientist"
 
 
 def test_profile_match_degraded_mode_uses_fallback_relevance(temp_dir: Path, empty_db: MCFDatabase):

--- a/tests/test_market_stats.py
+++ b/tests/test_market_stats.py
@@ -1,3 +1,6 @@
+from datetime import date
+from unittest.mock import patch
+
 from src.mcf.career_delta import CareerDeltaRequest
 from src.mcf.market_stats import (
     MISSING_TREND_SERIES,
@@ -163,6 +166,44 @@ def test_cache_refreshes_after_ttl_and_invalidate(empty_db):
     cache.invalidate()
     refreshed = cache.get_skill_stats("Python")
     assert refreshed.job_count == 2
+
+
+def test_market_stats_fetch_recent_rows_through_database_abstraction(empty_db):
+    cache = MarketStatsCache(empty_db, months=3)
+
+    with patch.object(empty_db, "fetch_recent_market_rows", return_value=[], create=True) as fetch_rows:
+        cache.refresh(force=True)
+
+    fetch_rows.assert_called_once()
+    assert isinstance(fetch_rows.call_args.args[0], date)
+
+
+def test_market_stats_accepts_database_native_posted_date_objects(empty_db):
+    labels = empty_db._month_labels(3)
+    year, month = [int(part) for part in labels[-1].split("-")]
+    cache = MarketStatsCache(empty_db, months=3)
+
+    with patch.object(
+        cache,
+        "_fetch_recent_rows",
+        return_value=[
+            {
+                "posted_date": date(year, month, 15),
+                "title": "Data Scientist",
+                "company_name": "Postgres Rows Ltd",
+                "categories": "Data Science",
+                "skills": "Python, SQL",
+                "salary_annual_min": 120000,
+                "salary_annual_max": 180000,
+                "title_family": "data-scientist",
+                "industry_bucket": "technology/data_and_ai",
+            }
+        ],
+    ):
+        aggregate = cache.get_skill_stats("Python")
+
+    assert aggregate.job_count == 1
+    assert aggregate.median_salary_annual == 150000
 
 
 def test_market_snapshot_returns_request_relevant_aggregates(empty_db):


### PR DESCRIPTION
## Summary
- treat Singapore/SG as a broad market region so hosted rows with blank subregions still match
- anchor market trend windows to the latest representative month and support Postgres date rows in market stats
- cache identical Match Lab profile and career-delta requests, and bust HF Docker clone cache during deploys

## Verification
- poetry run ruff check src/api/app.py src/mcf/database.py src/mcf/pg_database.py src/mcf/market_stats.py src/mcf/embeddings/search_engine.py src/mcf/career_delta_retrieval.py tests/test_api_app.py tests/test_market_intelligence.py tests/test_market_stats.py tests/test_career_delta_retrieval.py
- poetry run python -m pytest tests/test_market_intelligence.py tests/test_market_stats.py tests/test_career_delta_retrieval.py tests/test_career_delta_integration.py tests/test_api_app.py -q
- npm run build
- npm run test:unit

## Live deploy check
- HF API health: 200 healthy
- overview current_month_jobs: 2709
- profile match with region Singapore: 4 results, repeated request ~1.16s
- career-delta with location Singapore: 200, baseline_candidates 300, repeated request ~1.04s