### PR TITLE
Speed up page and tab loading

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -14,17 +14,19 @@ Usage:
 """
 
 import asyncio
+import copy
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
-from typing import Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from cachetools import TTLCache
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from ..mcf.career_delta import (
     CareerDeltaDependencies,
@@ -89,6 +91,10 @@ _search_engine: Optional[SemanticSearchEngine] = None
 _engine_executor = ThreadPoolExecutor(max_workers=1)
 MATCH_LAB_RESPONSE_CACHE_TTL_SECONDS = 300
 MATCH_LAB_RESPONSE_CACHE_MAX_ENTRIES = 128
+PUBLIC_RESPONSE_CACHE_TTL_SECONDS = 300
+PUBLIC_RESPONSE_CACHE_MAX_ENTRIES = 256
+
+T = TypeVar("T")
 
 
 class _CareerDeltaTaxonomyHelper:
@@ -147,6 +153,42 @@ def _get_match_lab_response_cache(engine: SemanticSearchEngine, name: str) -> TT
     )
     setattr(engine, attr, cache)
     return cache
+
+
+def _get_public_response_cache(engine: SemanticSearchEngine) -> TTLCache:
+    """Lazily construct a short-lived cache for expensive read-only API responses."""
+    cached = getattr(engine, "_public_response_cache", None)
+    if isinstance(cached, TTLCache):
+        return cached
+
+    cache = TTLCache(
+        maxsize=PUBLIC_RESPONSE_CACHE_MAX_ENTRIES,
+        ttl=PUBLIC_RESPONSE_CACHE_TTL_SECONDS,
+    )
+    setattr(engine, "_public_response_cache", cache)
+    return cache
+
+
+def _clone_cached_response(value: T) -> T:
+    """Return a defensive copy of a cached Pydantic/list/dict response."""
+    if isinstance(value, BaseModel):
+        return value.model_copy(deep=True)  # type: ignore[return-value]
+    return copy.deepcopy(value)
+
+
+async def _cached_public_response(
+    engine: SemanticSearchEngine,
+    cache_key: str,
+    producer: Callable[[], Awaitable[T]],
+) -> T:
+    cache = _get_public_response_cache(engine)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return _clone_cached_response(cached)
+
+    response = await producer()
+    cache[cache_key] = _clone_cached_response(response)
+    return response
 
 
 def _request_cache_key(prefix: str, request) -> str:
@@ -569,11 +611,19 @@ def _register_routes(app: FastAPI) -> None:
         Returns skills with job counts and optional cluster IDs for color coding.
         Useful for word clouds, bar charts, or skill distribution analysis.
         """
-        loop = asyncio.get_running_loop()
-        raw = await loop.run_in_executor(None, partial(engine.get_skill_cloud, min_jobs=min_jobs, limit=limit))
-        return SkillCloudResponse(
-            items=[SkillCloudItem(**item) for item in raw["items"]],
-            total_unique_skills=raw["total_unique_skills"],
+
+        async def produce() -> SkillCloudResponse:
+            loop = asyncio.get_running_loop()
+            raw = await loop.run_in_executor(None, partial(engine.get_skill_cloud, min_jobs=min_jobs, limit=limit))
+            return SkillCloudResponse(
+                items=[SkillCloudItem(**item) for item in raw["items"]],
+                total_unique_skills=raw["total_unique_skills"],
+            )
+
+        return await _cached_public_response(
+            engine,
+            f"skill_cloud:{min_jobs}:{limit}",
+            produce,
         )
 
     @app.get("/api/skills/related/{skill}", response_model=RelatedSkillsResponse)
@@ -605,10 +655,18 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> list[CompanySimilarity]:
         """Find companies with similar job profiles."""
-        internal_req = request.to_internal()
-        loop = asyncio.get_running_loop()
-        internal_results = await loop.run_in_executor(None, engine.find_similar_companies, internal_req)
-        return [CompanySimilarity.from_internal(r) for r in internal_results]
+
+        async def produce() -> list[CompanySimilarity]:
+            internal_req = request.to_internal()
+            loop = asyncio.get_running_loop()
+            internal_results = await loop.run_in_executor(None, engine.find_similar_companies, internal_req)
+            return [CompanySimilarity.from_internal(r) for r in internal_results]
+
+        return await _cached_public_response(
+            engine,
+            _request_cache_key("similar_companies", request),
+            produce,
+        )
 
     # -- Market intelligence endpoints ----------------------------------------
 
@@ -618,14 +676,22 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> OverviewResponse:
         """Get summary cards and top movers for the overview page."""
-        loop = asyncio.get_running_loop()
-        raw = await loop.run_in_executor(None, partial(engine.db.get_overview, months=months))
-        return OverviewResponse(
-            headline_metrics=OverviewMetric(**raw["headline_metrics"]),
-            rising_skills=[MomentumCard(**item) for item in raw["rising_skills"]],
-            rising_companies=[MomentumCard(**item) for item in raw["rising_companies"]],
-            salary_movement=SalaryMovement(**raw["salary_movement"]),
-            market_insights=[InsightCard(**item) for item in raw["market_insights"]],
+
+        async def produce() -> OverviewResponse:
+            loop = asyncio.get_running_loop()
+            raw = await loop.run_in_executor(None, partial(engine.db.get_overview, months=months))
+            return OverviewResponse(
+                headline_metrics=OverviewMetric(**raw["headline_metrics"]),
+                rising_skills=[MomentumCard(**item) for item in raw["rising_skills"]],
+                rising_companies=[MomentumCard(**item) for item in raw["rising_companies"]],
+                salary_movement=SalaryMovement(**raw["salary_movement"]),
+                market_insights=[InsightCard(**item) for item in raw["market_insights"]],
+            )
+
+        return await _cached_public_response(
+            engine,
+            f"overview:{months}",
+            produce,
         )
 
     @app.post("/api/trends/skills", response_model=list[SkillTrendSeries])
@@ -634,26 +700,34 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> list[SkillTrendSeries]:
         """Compare monthly demand trends for up to three skills."""
-        loop = asyncio.get_running_loop()
-        raw = await loop.run_in_executor(
-            None,
-            partial(
-                engine.db.get_skill_trends,
-                skills=request.skills,
-                months=request.months,
-                company_name=request.company,
-                employment_type=request.employment_type,
-                region=request.region,
-            ),
-        )
-        return [
-            SkillTrendSeries(
-                skill=item["skill"],
-                series=[TrendPoint(**point) for point in item["series"]],
-                latest=TrendPoint(**item["latest"]) if item.get("latest") else None,
+
+        async def produce() -> list[SkillTrendSeries]:
+            loop = asyncio.get_running_loop()
+            raw = await loop.run_in_executor(
+                None,
+                partial(
+                    engine.db.get_skill_trends,
+                    skills=request.skills,
+                    months=request.months,
+                    company_name=request.company,
+                    employment_type=request.employment_type,
+                    region=request.region,
+                ),
             )
-            for item in raw
-        ]
+            return [
+                SkillTrendSeries(
+                    skill=item["skill"],
+                    series=[TrendPoint(**point) for point in item["series"]],
+                    latest=TrendPoint(**item["latest"]) if item.get("latest") else None,
+                )
+                for item in raw
+            ]
+
+        return await _cached_public_response(
+            engine,
+            _request_cache_key("skill_trends", request),
+            produce,
+        )
 
     @app.post("/api/trends/roles", response_model=RoleTrendResponse)
     async def role_trends(
@@ -661,53 +735,74 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> RoleTrendResponse:
         """Get monthly trend data for a role/query string."""
-        loop = asyncio.get_running_loop()
-        raw = await loop.run_in_executor(
-            None,
-            partial(
-                engine.db.get_role_trend,
-                query=request.query,
-                months=request.months,
-                company_name=request.company,
-                employment_type=request.employment_type,
-                region=request.region,
-            ),
-        )
-        return RoleTrendResponse(
-            query=raw["query"],
-            series=[TrendPoint(**point) for point in raw["series"]],
-            latest=TrendPoint(**raw["latest"]) if raw.get("latest") else None,
+
+        async def produce() -> RoleTrendResponse:
+            loop = asyncio.get_running_loop()
+            raw = await loop.run_in_executor(
+                None,
+                partial(
+                    engine.db.get_role_trend,
+                    query=request.query,
+                    months=request.months,
+                    company_name=request.company,
+                    employment_type=request.employment_type,
+                    region=request.region,
+                ),
+            )
+            return RoleTrendResponse(
+                query=raw["query"],
+                series=[TrendPoint(**point) for point in raw["series"]],
+                latest=TrendPoint(**raw["latest"]) if raw.get("latest") else None,
+            )
+
+        return await _cached_public_response(
+            engine,
+            _request_cache_key("role_trends", request),
+            produce,
         )
 
     @app.get("/api/trends/companies/{company_name}", response_model=CompanyTrendResponse)
     async def company_trends(
         company_name: str,
         months: int = Query(3, ge=1, le=3, description="Number of months to analyze"),
+        include_similar: bool = Query(True, description="Include similar employer profiles"),
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> CompanyTrendResponse:
         """Get hiring trend, skill mix, and similar employers for one company."""
-        loop = asyncio.get_running_loop()
-        trend_raw, similar_raw = await asyncio.gather(
-            loop.run_in_executor(None, partial(engine.db.get_company_trend, company_name=company_name, months=months)),
-            loop.run_in_executor(
+
+        async def produce() -> CompanyTrendResponse:
+            loop = asyncio.get_running_loop()
+            trend_raw = await loop.run_in_executor(
                 None,
-                partial(
-                    engine.find_similar_companies,
-                    CompanySimilarityRequest(company_name=company_name, limit=6).to_internal(),
-                ),
-            ),
-        )
-        return CompanyTrendResponse(
-            company_name=trend_raw["company_name"],
-            series=[TrendPoint(**point) for point in trend_raw["series"]],
-            top_skills_by_month=[
-                MonthlySkillSnapshot(
-                    month=item["month"],
-                    skills=[SkillCloudItem(**skill) for skill in item["skills"]],
+                partial(engine.db.get_company_trend, company_name=company_name, months=months),
+            )
+            if include_similar:
+                similar_raw = await loop.run_in_executor(
+                    None,
+                    partial(
+                        engine.find_similar_companies,
+                        CompanySimilarityRequest(company_name=company_name, limit=6).to_internal(),
+                    ),
                 )
-                for item in trend_raw["top_skills_by_month"]
-            ],
-            similar_companies=[CompanySimilarity.from_internal(item) for item in similar_raw],
+            else:
+                similar_raw = []
+            return CompanyTrendResponse(
+                company_name=trend_raw["company_name"],
+                series=[TrendPoint(**point) for point in trend_raw["series"]],
+                top_skills_by_month=[
+                    MonthlySkillSnapshot(
+                        month=item["month"],
+                        skills=[SkillCloudItem(**skill) for skill in item["skills"]],
+                    )
+                    for item in trend_raw["top_skills_by_month"]
+                ],
+                similar_companies=[CompanySimilarity.from_internal(item) for item in similar_raw],
+            )
+
+        return await _cached_public_response(
+            engine,
+            f"company_trends:{company_name.lower()}:{months}:{include_similar}",
+            produce,
         )
 
     @app.post("/api/match/profile", response_model=ProfileMatchResponse)
@@ -812,18 +907,26 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> StatsResponse:
         """Get system statistics (index size, coverage, etc.)."""
-        loop = asyncio.get_running_loop()
-        raw = await loop.run_in_executor(_engine_executor, engine.get_stats)
-        emb = raw.get("embedding_stats", {})
-        idx = raw.get("index_stats", {})
-        return StatsResponse(
-            total_jobs=emb.get("total_jobs", 0),
-            jobs_with_embeddings=emb.get("job_embeddings", 0),
-            embedding_coverage_pct=emb.get("coverage_pct", 0.0),
-            unique_skills=emb.get("skill_embeddings", 0),
-            unique_companies=emb.get("unique_companies", 0),
-            index_size_mb=idx.get("index_size_mb", 0.0),
-            model_version=raw.get("model_version", "unknown"),
+
+        async def produce() -> StatsResponse:
+            loop = asyncio.get_running_loop()
+            raw = await loop.run_in_executor(_engine_executor, engine.get_stats)
+            emb = raw.get("embedding_stats", {})
+            idx = raw.get("index_stats", {})
+            return StatsResponse(
+                total_jobs=emb.get("total_jobs", 0),
+                jobs_with_embeddings=emb.get("job_embeddings", 0),
+                embedding_coverage_pct=emb.get("coverage_pct", 0.0),
+                unique_skills=emb.get("skill_embeddings", 0),
+                unique_companies=emb.get("unique_companies", 0),
+                index_size_mb=idx.get("index_size_mb", 0.0),
+                model_version=raw.get("model_version", "unknown"),
+            )
+
+        return await _cached_public_response(
+            engine,
+            "stats",
+            produce,
         )
 
     @app.get("/api/analytics/popular")
@@ -833,8 +936,16 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> list[dict]:
         """Get most popular search queries."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, partial(engine.db.get_popular_queries, days=days, limit=limit))
+
+        async def produce() -> list[dict]:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, partial(engine.db.get_popular_queries, days=days, limit=limit))
+
+        return await _cached_public_response(
+            engine,
+            f"popular_queries:{days}:{limit}",
+            produce,
+        )
 
     @app.get("/api/analytics/performance")
     async def performance_stats(
@@ -842,8 +953,16 @@ def _register_routes(app: FastAPI) -> None:
         engine: SemanticSearchEngine = Depends(get_engine),
     ) -> dict:
         """Get search latency percentiles (p50, p90, p95, p99)."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, partial(engine.db.get_search_latency_percentiles, days=days))
+
+        async def produce() -> dict:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, partial(engine.db.get_search_latency_percentiles, days=days))
+
+        return await _cached_public_response(
+            engine,
+            f"performance_stats:{days}",
+            produce,
+        )
 
     @app.get("/health", response_model=HealthResponse)
     async def health_check() -> HealthResponse:

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,8 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { NavLink, Route, Routes, useLocation } from 'react-router-dom'
 import { Bars3Icon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
-import CommandPalette from '@/components/shell/CommandPalette'
-import MobileNav from '@/components/shell/MobileNav'
 import ThemeToggle from '@/components/shell/ThemeToggle'
 import TopProgressBar from '@/components/shell/TopProgressBar'
 import { IconButton, Kbd, Spinner } from '@/components/ui'
@@ -10,10 +9,19 @@ import { useHotkeys } from '@/hooks/useHotkeys'
 
 type NavItem = { to: string; label: string; end?: boolean }
 
-const OverviewPage = lazy(() => import('@/pages/OverviewPage'))
-const TrendsPage = lazy(() => import('@/pages/TrendsPage'))
-const MatchLabPage = lazy(() => import('@/pages/MatchLabPage'))
-const SearchPage = lazy(() => import('@/pages/SearchPage'))
+const loadOverviewPage = () => import('@/pages/OverviewPage')
+const loadTrendsPage = () => import('@/pages/TrendsPage')
+const loadMatchLabPage = () => import('@/pages/MatchLabPage')
+const loadSearchPage = () => import('@/pages/SearchPage')
+const loadCommandPalette = () => import('@/components/shell/CommandPalette')
+const loadMobileNav = () => import('@/components/shell/MobileNav')
+
+const OverviewPage = lazy(loadOverviewPage)
+const TrendsPage = lazy(loadTrendsPage)
+const MatchLabPage = lazy(loadMatchLabPage)
+const SearchPage = lazy(loadSearchPage)
+const CommandPalette = lazy(loadCommandPalette)
+const MobileNav = lazy(loadMobileNav)
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { to: '/', label: 'Overview', end: true },
@@ -21,6 +29,20 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { to: '/match-lab', label: 'Match Lab' },
   { to: '/search', label: 'Search & Similarity' },
 ]
+
+const ROUTE_LOADERS: Record<string, () => Promise<unknown>> = {
+  '/': loadOverviewPage,
+  '/trends': loadTrendsPage,
+  '/match-lab': loadMatchLabPage,
+  '/search': loadSearchPage,
+}
+
+const TREND_PREFETCH = {
+  skills: ['Customer Service', 'Microsoft Excel', 'Communication Skills'],
+  role: 'customer service',
+  company: 'RECRUIT EXPERT PTE. LTD.',
+  months: 3,
+} as const
 
 function RouteLoading() {
   return (
@@ -34,13 +56,109 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const location = useLocation()
+  const queryClient = useQueryClient()
 
   const activeItem =
     NAV_ITEMS.find((item) =>
       item.end ? location.pathname === item.to : location.pathname.startsWith(item.to),
     ) ?? NAV_ITEMS[0]
 
-  const openPalette = useCallback(() => setPaletteOpen(true), [])
+  const prefetchRouteModule = useCallback((to: string) => {
+    void ROUTE_LOADERS[to]?.()
+  }, [])
+
+  const prefetchPageData = useCallback(
+    (to: string) => {
+      void import('@/services/api').then(
+        ({
+          findSimilarCompanies,
+          getCompanyTrend,
+          getHealth,
+          getOverview,
+          getPerformanceStats,
+          getPopularQueries,
+          getRoleTrend,
+          getSkillCloud,
+          getSkillTrends,
+          getStats,
+        }) => {
+          if (to === '/') {
+            void queryClient.prefetchQuery({
+              queryKey: ['overview', 3],
+              queryFn: () => getOverview(3),
+            })
+            void queryClient.prefetchQuery({ queryKey: ['stats'], queryFn: getStats })
+            void queryClient.prefetchQuery({
+              queryKey: ['popularQueries'],
+              queryFn: () => getPopularQueries(30, 8),
+            })
+            void queryClient.prefetchQuery({
+              queryKey: ['performanceStats'],
+              queryFn: () => getPerformanceStats(30),
+            })
+          }
+
+          if (to === '/trends') {
+            void queryClient.prefetchQuery({
+              queryKey: ['overview', TREND_PREFETCH.months],
+              queryFn: () => getOverview(TREND_PREFETCH.months),
+            })
+            void queryClient.prefetchQuery({
+              queryKey: ['skillTrends', TREND_PREFETCH.skills, TREND_PREFETCH.months, '', ''],
+              queryFn: () =>
+                getSkillTrends({
+                  skills: [...TREND_PREFETCH.skills],
+                  months: TREND_PREFETCH.months,
+                  employment_type: null,
+                  region: null,
+                }),
+            })
+            void queryClient.prefetchQuery({
+              queryKey: ['roleTrend', TREND_PREFETCH.role, TREND_PREFETCH.months, '', ''],
+              queryFn: () =>
+                getRoleTrend({
+                  query: TREND_PREFETCH.role,
+                  months: TREND_PREFETCH.months,
+                  employment_type: null,
+                  region: null,
+                }),
+            })
+            void queryClient.prefetchQuery({
+              queryKey: ['companyTrend', TREND_PREFETCH.company, TREND_PREFETCH.months],
+              queryFn: () => getCompanyTrend(TREND_PREFETCH.company, TREND_PREFETCH.months, false),
+            })
+            void queryClient.prefetchQuery({
+              queryKey: ['similarCompanies', TREND_PREFETCH.company],
+              queryFn: () => findSimilarCompanies({ company_name: TREND_PREFETCH.company, limit: 6 }),
+            })
+          }
+
+          if (to === '/search') {
+            void queryClient.prefetchQuery({
+              queryKey: ['skillCloud'],
+              queryFn: () => getSkillCloud(10, 80),
+              staleTime: 10 * 60 * 1000,
+            })
+            void queryClient.prefetchQuery({ queryKey: ['health'], queryFn: getHealth })
+          }
+        },
+      )
+    },
+    [queryClient],
+  )
+
+  const prefetchRoute = useCallback(
+    (to: string) => {
+      prefetchRouteModule(to)
+      prefetchPageData(to)
+    },
+    [prefetchPageData, prefetchRouteModule],
+  )
+
+  const openPalette = useCallback(() => {
+    void loadCommandPalette()
+    setPaletteOpen(true)
+  }, [])
   const closePalette = useCallback(() => setPaletteOpen(false), [])
 
   useEffect(() => {
@@ -52,6 +170,28 @@ export default function App() {
     mql.addEventListener('change', close)
     return () => mql.removeEventListener('change', close)
   }, [])
+
+  useEffect(() => {
+    const prefetchIdleWork = () => {
+      for (const item of NAV_ITEMS) {
+        prefetchRouteModule(item.to)
+      }
+      prefetchPageData('/')
+      prefetchPageData('/search')
+    }
+
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number
+      cancelIdleCallback?: (handle: number) => void
+    }
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      const handle = idleWindow.requestIdleCallback(prefetchIdleWork, { timeout: 2500 })
+      return () => idleWindow.cancelIdleCallback?.(handle)
+    }
+
+    const handle = window.setTimeout(prefetchIdleWork, 1200)
+    return () => window.clearTimeout(handle)
+  }, [prefetchPageData, prefetchRouteModule])
 
   useHotkeys({
     'mod+k': (e) => {
@@ -84,6 +224,8 @@ export default function App() {
                     key={item.to}
                     to={item.to}
                     end={item.end}
+                    onMouseEnter={() => prefetchRoute(item.to)}
+                    onFocus={() => prefetchRoute(item.to)}
                     className={({ isActive }) =>
                       `rounded-full px-4 py-2 text-sm font-semibold transition ${
                         isActive
@@ -101,6 +243,8 @@ export default function App() {
                 <button
                   type="button"
                   onClick={openPalette}
+                  onMouseEnter={() => void loadCommandPalette()}
+                  onFocus={() => void loadCommandPalette()}
                   className="hidden items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-1)] px-3 py-1.5 text-xs font-medium text-[color:var(--ink-muted)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--ink)] focus-visible:ring-2 focus-visible:ring-[color:var(--brand)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)] sm:inline-flex"
                   aria-label="Open command palette"
                 >
@@ -116,6 +260,8 @@ export default function App() {
                   icon={<MagnifyingGlassIcon />}
                   size="sm"
                   onClick={openPalette}
+                  onMouseEnter={() => void loadCommandPalette()}
+                  onFocus={() => void loadCommandPalette()}
                   className="sm:hidden"
                 />
                 <ThemeToggle />
@@ -123,7 +269,12 @@ export default function App() {
                   aria-label="Open navigation menu"
                   icon={<Bars3Icon />}
                   size="sm"
-                  onClick={() => setMobileNavOpen(true)}
+                  onClick={() => {
+                    void loadMobileNav()
+                    setMobileNavOpen(true)
+                  }}
+                  onMouseEnter={() => void loadMobileNav()}
+                  onFocus={() => void loadMobileNav()}
                   className="lg:hidden"
                 />
               </div>
@@ -149,12 +300,21 @@ export default function App() {
         </main>
       </div>
 
-      <CommandPalette open={paletteOpen} onClose={closePalette} />
-      <MobileNav
-        open={mobileNavOpen}
-        onClose={() => setMobileNavOpen(false)}
-        items={NAV_ITEMS}
-      />
+      {paletteOpen ? (
+        <Suspense fallback={null}>
+          <CommandPalette open={paletteOpen} onClose={closePalette} />
+        </Suspense>
+      ) : null}
+      {mobileNavOpen ? (
+        <Suspense fallback={null}>
+          <MobileNav
+            open={mobileNavOpen}
+            onClose={() => setMobileNavOpen(false)}
+            items={NAV_ITEMS}
+            onPrefetch={prefetchRoute}
+          />
+        </Suspense>
+      ) : null}
     </div>
   )
 }

--- a/src/frontend/src/components/shell/MobileNav.tsx
+++ b/src/frontend/src/components/shell/MobileNav.tsx
@@ -14,9 +14,10 @@ interface MobileNavProps {
   open: boolean
   onClose: () => void
   items: ReadonlyArray<NavItem>
+  onPrefetch?: (to: string) => void
 }
 
-export default function MobileNav({ open, onClose, items }: MobileNavProps) {
+export default function MobileNav({ open, onClose, items, onPrefetch }: MobileNavProps) {
   return (
     <Transition show={open} as={Fragment}>
       <Dialog onClose={onClose} className="relative z-[65] lg:hidden">
@@ -60,6 +61,8 @@ export default function MobileNav({ open, onClose, items }: MobileNavProps) {
                     key={item.to}
                     to={item.to}
                     end={item.end}
+                    onMouseEnter={() => onPrefetch?.(item.to)}
+                    onFocus={() => onPrefetch?.(item.to)}
                     onClick={onClose}
                     className={({ isActive }) =>
                       `rounded-[var(--radius-md)] px-4 py-3 text-sm font-semibold transition ${

--- a/src/frontend/src/pages/OverviewPage.tsx
+++ b/src/frontend/src/pages/OverviewPage.tsx
@@ -16,7 +16,7 @@ function formatMoney(value: number | null): string {
 }
 
 export default function OverviewPage() {
-  const overview = useQuery({ queryKey: ['overview'], queryFn: () => getOverview(12) })
+  const overview = useQuery({ queryKey: ['overview', 3], queryFn: () => getOverview(3) })
   const stats = useQuery({ queryKey: ['stats'], queryFn: getStats })
   const popular = useQuery({
     queryKey: ['popularQueries'],

--- a/src/frontend/src/pages/TrendsPage.tsx
+++ b/src/frontend/src/pages/TrendsPage.tsx
@@ -4,7 +4,7 @@ import { ArrowDownRightIcon, ArrowRightIcon, ArrowUpRightIcon } from '@heroicons
 import TrendSparkline from '@/components/TrendSparkline'
 import { Card, Chip, EmptyState, Input, Select, Skeleton } from '@/components/ui'
 import type { ChipIntent, SelectOption } from '@/components/ui'
-import { getCompanyTrend, getOverview, getRoleTrend, getSkillTrends } from '@/services/api'
+import { findSimilarCompanies, getCompanyTrend, getOverview, getRoleTrend, getSkillTrends } from '@/services/api'
 import { getMomentumSignal, TREND_WINDOW_OPTIONS } from '@/services/trendSignals'
 import type { SkillTrendSeries, TrendPoint } from '@/types/api'
 
@@ -165,14 +165,22 @@ export default function TrendsPage() {
 
   const companyTrend = useQuery({
     queryKey: ['companyTrend', companyInput, months],
-    queryFn: () => getCompanyTrend(companyInput, months),
+    queryFn: () => getCompanyTrend(companyInput, months, false),
     enabled: companyInput.trim().length > 0,
+  })
+
+  const similarCompanies = useQuery({
+    queryKey: ['similarCompanies', companyInput],
+    queryFn: () => findSimilarCompanies({ company_name: companyInput, limit: 6 }),
+    enabled: companyInput.trim().length > 0 && companyTrend.data != null,
+    staleTime: 10 * 60 * 1000,
   })
 
   const roleLatest = roleTrend.data?.latest ?? null
   const companyLatest = latestPoint(companyTrend.data?.series ?? [])
   const companyActiveMonths = activeMonths(companyTrend.data?.series ?? [])
   const companySkillSnapshots = companyTrend.data?.top_skills_by_month.filter((snapshot) => snapshot.skills.length) ?? []
+  const similarEmployerProfiles = similarCompanies.data ?? companyTrend.data?.similar_companies ?? []
 
   return (
     <div className="space-y-8">
@@ -397,8 +405,10 @@ export default function TrendsPage() {
               <div className="rounded-[var(--radius-lg)] bg-[color:var(--surface-2)] p-5">
                 <p className="text-sm font-semibold text-[color:var(--ink)]">Similar hiring profiles</p>
                 <div className="mt-4 space-y-2">
-                  {companyTrend.data.similar_companies.length ? (
-                    companyTrend.data.similar_companies.map((company) => (
+                  {similarCompanies.isLoading ? (
+                    Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} height={58} rounded="md" />)
+                  ) : similarEmployerProfiles.length ? (
+                    similarEmployerProfiles.map((company) => (
                       <Card
                         key={company.company_name}
                         radius="md"

--- a/src/frontend/src/services/api.ts
+++ b/src/frontend/src/services/api.ts
@@ -101,10 +101,14 @@ export async function findSimilarCompanies(req: CompanySimilarityRequest): Promi
   return data
 }
 
-export async function getCompanyTrend(companyName: string, months = 12): Promise<CompanyTrendResponse> {
+export async function getCompanyTrend(
+  companyName: string,
+  months = 3,
+  includeSimilar = true,
+): Promise<CompanyTrendResponse> {
   const { data } = await client.get<CompanyTrendResponse>(
     `/api/trends/companies/${encodeURIComponent(companyName)}`,
-    { params: { months } },
+    { params: { months, include_similar: includeSimilar } },
   )
   return data
 }
@@ -136,7 +140,7 @@ export async function getCareerDeltaScenarioDetail(scenarioId: string): Promise<
   return data
 }
 
-export async function getOverview(months = 12): Promise<OverviewResponse> {
+export async function getOverview(months = 3): Promise<OverviewResponse> {
   const { data } = await client.get<OverviewResponse>('/api/overview', {
     params: { months },
   })

--- a/src/mcf/database.py
+++ b/src/mcf/database.py
@@ -2640,24 +2640,41 @@ class MCFDatabase:
     ) -> list[dict]:
         """Return monthly trend series for each requested skill."""
         anchor = self._trend_anchor_date()
-        market_counts = self._get_market_monthly_counts(
+        labels = self._month_labels(months, anchor)
+        rows = self._fetch_trend_rows(
             months=months,
             company_name=company_name,
             employment_type=employment_type,
             region=region,
             anchor_date=anchor,
         )
+        market_counts: Counter = Counter()
+        skill_counts: dict[str, Counter] = {skill: Counter() for skill in skills}
+        skill_salarys: dict[str, dict[str, list[int]]] = {skill: {label: [] for label in labels} for skill in skills}
+        skill_needles = {skill: skill.lower() for skill in skills}
+
+        for row in rows:
+            month = posted_month_key(row["posted_date"])
+            if month not in labels:
+                continue
+            market_counts[month] += 1
+            row_skills = (row["skills"] or "").lower()
+            salary = self._salary_midpoint(row)
+            for skill, needle in skill_needles.items():
+                if needle in row_skills:
+                    skill_counts[skill][month] += 1
+                    if salary is not None:
+                        skill_salarys[skill][month].append(salary)
+
+        market_count_map = {label: market_counts.get(label, 0) for label in labels}
         trends = []
         for skill in skills:
-            rows = self._fetch_trend_rows(
-                months=months,
-                company_name=company_name,
-                employment_type=employment_type,
-                region=region,
-                skill=skill,
-                anchor_date=anchor,
+            series = self._series_from_aggregates(
+                month_counts=skill_counts[skill],
+                salary_buckets=skill_salarys[skill],
+                labels=labels,
+                market_counts=market_count_map,
             )
-            series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
             trends.append(
                 {
                     "skill": skill,
@@ -2917,42 +2934,61 @@ class MCFDatabase:
         Returns:
             Dict with job_count, avg_salary, top_skills
         """
+        return self.get_company_stats_bulk([company_name]).get(
+            company_name,
+            {"job_count": 0, "avg_salary": None, "top_skills": []},
+        )
+
+    def get_company_stats_bulk(self, company_names: list[str]) -> dict[str, dict]:
+        """Get statistics for multiple companies with shared database scans."""
+        names = list(dict.fromkeys(name for name in company_names if name))
+        if not names:
+            return {}
+
+        placeholders = ", ".join("?" for _ in names)
         with self._connection() as conn:
-            row = conn.execute(
-                """
+            rows = conn.execute(
+                f"""
                 SELECT
+                    company_name,
                     COUNT(*) as job_count,
                     AVG(salary_annual_min) as avg_salary_min,
                     AVG(salary_annual_max) as avg_salary_max
                 FROM jobs
-                WHERE company_name = ?
+                WHERE company_name IN ({placeholders})
+                GROUP BY company_name
                 """,
-                (company_name,),
-            ).fetchone()
-
-            # Get skills for this company
-            skills_rows = conn.execute(
-                "SELECT skills FROM jobs WHERE company_name = ? AND skills IS NOT NULL",
-                (company_name,),
+                names,
             ).fetchall()
 
-        # Parse and count skills
-        skill_counts: Counter = Counter()
-        for r in skills_rows:
-            skills = [s.strip() for s in r[0].split(",") if s.strip()]
-            skill_counts.update(skills)
+            skills_rows = conn.execute(
+                f"SELECT company_name, skills FROM jobs WHERE company_name IN ({placeholders}) AND skills IS NOT NULL",
+                names,
+            ).fetchall()
 
-        top_skills = [s for s, _ in skill_counts.most_common(10)]
+        skill_counts: dict[str, Counter] = {name: Counter() for name in names}
+        for row in skills_rows:
+            skills = [skill.strip() for skill in row[1].split(",") if skill.strip()]
+            skill_counts[row[0]].update(skills)
 
-        avg_salary = None
-        if row[1] and row[2]:
-            avg_salary = int((row[1] + row[2]) / 2)
-
-        return {
-            "job_count": row[0],
-            "avg_salary": avg_salary,
-            "top_skills": top_skills,
+        stats = {
+            name: {
+                "job_count": 0,
+                "avg_salary": None,
+                "top_skills": [skill for skill, _ in skill_counts[name].most_common(10)],
+            }
+            for name in names
         }
+        for row in rows:
+            avg_salary = None
+            if row[2] and row[3]:
+                avg_salary = int((row[2] + row[3]) / 2)
+            stats[row[0]] = {
+                "job_count": row[1],
+                "avg_salary": avg_salary,
+                "top_skills": [skill for skill, _ in skill_counts[row[0]].most_common(10)],
+            }
+        return stats
 
     def get_all_unique_skills(self) -> list[str]:
         """

--- a/src/mcf/embeddings/search_engine.py
+++ b/src/mcf/embeddings/search_engine.py
@@ -702,6 +702,12 @@ class SemanticSearchEngine:
         # Fallback: on-the-fly single centroid via jobs index
         return self._find_similar_companies_fallback(request)
 
+    def _get_company_stats_bulk(self, company_names: list[str]) -> dict[str, dict]:
+        bulk_getter = getattr(self.db, "get_company_stats_bulk", None)
+        if callable(bulk_getter):
+            return bulk_getter(company_names)
+        return {company_name: self.db.get_company_stats(company_name) for company_name in company_names}
+
     def _find_similar_companies_multi_centroid(
         self,
         request: CompanySimilarityRequest,
@@ -740,9 +746,10 @@ class SemanticSearchEngine:
         sorted_companies = sorted(company_scores.items(), key=lambda x: x[1], reverse=True)[: request.limit]
 
         # Enrich with company stats
+        company_stats = self._get_company_stats_bulk([company_name for company_name, _ in sorted_companies])
         results_list: list[CompanySimilarity] = []
         for company_name, score in sorted_companies:
-            stats = self.db.get_company_stats(company_name)
+            stats = company_stats.get(company_name, {})
             results_list.append(
                 CompanySimilarity(
                     company_name=company_name,
@@ -813,9 +820,10 @@ class SemanticSearchEngine:
         company_avg.sort(key=lambda x: x[1], reverse=True)
 
         # Enrich with company stats
+        company_stats = self._get_company_stats_bulk([company_name for company_name, _ in company_avg[: request.limit]])
         results: list[CompanySimilarity] = []
         for company_name, score in company_avg[: request.limit]:
-            stats = self.db.get_company_stats(company_name)
+            stats = company_stats.get(company_name, {})
             results.append(
                 CompanySimilarity(
                     company_name=company_name,

--- a/src/mcf/pg_database.py
+++ b/src/mcf/pg_database.py
@@ -1631,24 +1631,41 @@ class PostgresDatabase:
         region: str | None = None,
     ) -> list[dict]:
         anchor = self._trend_anchor_date()
-        market_counts = self._get_market_monthly_counts(
-            months,
-            company_name,
-            employment_type,
-            region,
+        labels = self._month_labels(months, anchor)
+        rows = self._fetch_trend_rows(
+            months=months,
+            company_name=company_name,
+            employment_type=employment_type,
+            region=region,
             anchor_date=anchor,
         )
+        market_counts: Counter = Counter()
+        skill_counts: dict[str, Counter] = {skill: Counter() for skill in skills}
+        skill_salarys: dict[str, dict[str, list[int]]] = {skill: {label: [] for label in labels} for skill in skills}
+        skill_needles = {skill: skill.lower() for skill in skills}
+
+        for row in rows:
+            month = posted_month_key(row["posted_date"])
+            if month not in labels:
+                continue
+            market_counts[month] += 1
+            row_skills = (row["skills"] or "").lower()
+            salary = self._salary_midpoint(row)
+            for skill, needle in skill_needles.items():
+                if needle in row_skills:
+                    skill_counts[skill][month] += 1
+                    if salary is not None:
+                        skill_salarys[skill][month].append(salary)
+
+        market_count_map = {label: market_counts.get(label, 0) for label in labels}
         trends = []
         for skill in skills:
-            rows = self._fetch_trend_rows(
-                months=months,
-                company_name=company_name,
-                employment_type=employment_type,
-                region=region,
-                skill=skill,
-                anchor_date=anchor,
+            series = self._series_from_aggregates(
+                month_counts=skill_counts[skill],
+                salary_buckets=skill_salarys[skill],
+                labels=labels,
+                market_counts=market_count_map,
             )
-            series = self._rows_to_series(rows, months, market_counts, anchor_date=anchor)
             trends.append({"skill": skill, "series": series, "latest": series[-1] if series else None})
         return trends
 
@@ -1853,33 +1870,61 @@ class PostgresDatabase:
         return [row["company_name"] for row in rows]
 
     def get_company_stats(self, company_name: str) -> dict:
+        return self.get_company_stats_bulk([company_name]).get(
+            company_name,
+            {"job_count": 0, "avg_salary": None, "top_skills": []},
+        )
+
+    def get_company_stats_bulk(self, company_names: list[str]) -> dict[str, dict]:
+        names = list(dict.fromkeys(name for name in company_names if name))
+        if not names:
+            return {}
+
+        placeholders = ", ".join("%s" for _ in names)
         with self._connection() as conn:
-            row = conn.execute(
-                """
+            rows = conn.execute(
+                f"""
                 SELECT
+                    company_name,
                     COUNT(*) AS job_count,
                     AVG(salary_annual_min) AS avg_salary_min,
                     AVG(salary_annual_max) AS avg_salary_max
                 FROM jobs
-                WHERE company_name = %s
+                WHERE company_name IN ({placeholders})
+                GROUP BY company_name
                 """,
-                (company_name,),
-            ).fetchone()
-            skills_rows = conn.execute(
-                "SELECT skills FROM jobs WHERE company_name = %s AND skills IS NOT NULL",
-                (company_name,),
+                names,
             ).fetchall()
-        skill_counts: Counter = Counter()
-        for result in skills_rows:
-            skill_counts.update([skill.strip() for skill in (result["skills"] or "").split(",") if skill.strip()])
-        avg_salary = None
-        if row["avg_salary_min"] and row["avg_salary_max"]:
-            avg_salary = int((row["avg_salary_min"] + row["avg_salary_max"]) / 2)
-        return {
-            "job_count": row["job_count"],
-            "avg_salary": avg_salary,
-            "top_skills": [name for name, _ in skill_counts.most_common(10)],
+            skills_rows = conn.execute(
+                f"SELECT company_name, skills FROM jobs WHERE company_name IN ({placeholders}) AND skills IS NOT NULL",
+                names,
+            ).fetchall()
+
+        skill_counts: dict[str, Counter] = {name: Counter() for name in names}
+        for row in skills_rows:
+            skill_counts[row["company_name"]].update(
+                [skill.strip() for skill in (row["skills"] or "").split(",") if skill.strip()]
+            )
+
+        stats = {
+            name: {
+                "job_count": 0,
+                "avg_salary": None,
+                "top_skills": [skill for skill, _ in skill_counts[name].most_common(10)],
+            }
+            for name in names
         }
+        for row in rows:
+            avg_salary = None
+            if row["avg_salary_min"] and row["avg_salary_max"]:
+                avg_salary = int((row["avg_salary_min"] + row["avg_salary_max"]) / 2)
+            company_name = row["company_name"]
+            stats[company_name] = {
+                "job_count": row["job_count"],
+                "avg_salary": avg_salary,
+                "top_skills": [skill for skill, _ in skill_counts[company_name].most_common(10)],
+            }
+        return stats
 
     def get_all_unique_skills(self) -> list[str]:
         with self._connection() as conn:

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -439,6 +439,15 @@ class TestSkillCloudEndpoint:
         assert data["total_unique_skills"] == 1200
         mock_engine.get_skill_cloud.assert_called_once()
 
+    def test_skill_cloud_caches_identical_requests(self, client, mock_engine):
+        first = client.get("/api/skills/cloud?min_jobs=10&limit=80")
+        second = client.get("/api/skills/cloud?min_jobs=10&limit=80")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine.get_skill_cloud.assert_called_once()
+
     def test_skill_cloud_with_params(self, client, mock_engine):
         resp = client.get("/api/skills/cloud?min_jobs=100&limit=50")
         assert resp.status_code == 200
@@ -515,6 +524,17 @@ class TestCompanySimilarityEndpoint:
         assert data[0]["company_name"] == "SimilarCo"
         assert data[0]["similarity_score"] == 0.85
 
+    def test_similar_companies_caches_identical_requests(self, client, mock_engine):
+        payload = {"company_name": "Google", "limit": 6}
+
+        first = client.post("/api/companies/similar", json=payload)
+        second = client.post("/api/companies/similar", json=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine.find_similar_companies.assert_called_once()
+
     def test_empty_company_rejected(self, client):
         resp = client.post(
             "/api/companies/similar",
@@ -533,6 +553,15 @@ class TestMarketIntelligenceEndpoints:
         assert data["headline_metrics"]["total_jobs"] == 50000
         mock_engine.db.get_overview.assert_called_once_with(months=12)
 
+    def test_overview_caches_identical_requests(self, client, mock_engine):
+        first = client.get("/api/overview?months=3")
+        second = client.get("/api/overview?months=3")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine.db.get_overview.assert_called_once_with(months=3)
+
     def test_skill_trends(self, client, mock_engine):
         resp = client.post("/api/trends/skills", json={"skills": ["Python"], "months": 3})
         assert resp.status_code == 200
@@ -543,6 +572,17 @@ class TestMarketIntelligenceEndpoints:
         assert data[0]["latest"]["momentum_label"] == "Rising"
         mock_engine.db.get_skill_trends.assert_called_once()
         assert mock_engine.db.get_skill_trends.call_args.kwargs["months"] == 3
+
+    def test_skill_trends_cache_identical_requests(self, client, mock_engine):
+        payload = {"skills": ["Python"], "months": 3}
+
+        first = client.post("/api/trends/skills", json=payload)
+        second = client.post("/api/trends/skills", json=payload)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json() == second.json()
+        mock_engine.db.get_skill_trends.assert_called_once()
 
     def test_role_trends(self, client, mock_engine):
         resp = client.post("/api/trends/roles", json={"query": "data scientist", "months": 3})
@@ -557,6 +597,16 @@ class TestMarketIntelligenceEndpoints:
         data = resp.json()
         assert data["company_name"] == "TestCo"
         assert data["similar_companies"][0]["company_name"] == "SimilarCo"
+
+    def test_company_trends_can_defer_similar_profiles(self, client, mock_engine):
+        resp = client.get("/api/trends/companies/TestCo?months=3&include_similar=false")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["company_name"] == "TestCo"
+        assert data["similar_companies"] == []
+        mock_engine.db.get_company_trend.assert_called_once()
+        mock_engine.find_similar_companies.assert_not_called()
 
     def test_trends_reject_windows_beyond_hosted_dataset(self, client):
         skill_resp = client.post("/api/trends/skills", json={"skills": ["Python"], "months": 12})

--- a/tests/test_market_intelligence.py
+++ b/tests/test_market_intelligence.py
@@ -128,6 +128,34 @@ def test_trend_momentum_status_tracks_direction_when_baseline_exists(empty_db: M
     assert latest["momentum_label"] == "Rising"
 
 
+def test_skill_trends_aggregate_multiple_skills_from_one_scan(empty_db: MCFDatabase):
+    _insert_job(
+        empty_db,
+        title="Platform Engineer",
+        company_name="Alpha",
+        skills=["Python", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=20),
+        salary_min=9000,
+        salary_max=12000,
+    )
+    _insert_job(
+        empty_db,
+        title="Support Engineer",
+        company_name="Beta",
+        skills=["Customer Service", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=15),
+        salary_min=4500,
+        salary_max=6500,
+    )
+
+    with patch.object(empty_db, "_fetch_trend_rows", wraps=empty_db._fetch_trend_rows) as fetch_rows:
+        trends = empty_db.get_skill_trends(["Python", "SQL", "Customer Service"], months=3)
+
+    assert fetch_rows.call_count == 1
+    latest_counts = {trend["skill"]: trend["latest"]["job_count"] for trend in trends}
+    assert latest_counts == {"Python": 1, "SQL": 2, "Customer Service": 1}
+
+
 def test_role_trend_uses_annual_salary_median(empty_db: MCFDatabase):
     _insert_job(
         empty_db,
@@ -172,6 +200,44 @@ def test_company_trend_top_skills_include_cluster_id(empty_db: MCFDatabase):
     assert trend["top_skills_by_month"]
     latest_skills = next(item for item in trend["top_skills_by_month"] if item["skills"])
     assert latest_skills["skills"][0]["cluster_id"] is None
+
+
+def test_company_stats_bulk_returns_counts_salary_and_skills(empty_db: MCFDatabase):
+    _insert_job(
+        empty_db,
+        title="Data Scientist",
+        company_name="Insight Labs",
+        skills=["Python", "SQL"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=20),
+        salary_min=10000,
+        salary_max=14000,
+    )
+    _insert_job(
+        empty_db,
+        title="Analytics Engineer",
+        company_name="Insight Labs",
+        skills=["Python", "Airflow"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=15),
+        salary_min=8000,
+        salary_max=10000,
+    )
+    _insert_job(
+        empty_db,
+        title="Support Specialist",
+        company_name="Support Co",
+        skills=["Customer Service"],
+        posted_days_ago=posted_days_ago_for_month_offset(0, day=12),
+        salary_min=3000,
+        salary_max=4000,
+    )
+
+    stats = empty_db.get_company_stats_bulk(["Insight Labs", "Support Co", "Missing Co"])
+
+    assert stats["Insight Labs"]["job_count"] == 2
+    assert stats["Insight Labs"]["avg_salary"] == 126000
+    assert stats["Insight Labs"]["top_skills"][0] == "Python"
+    assert stats["Support Co"]["job_count"] == 1
+    assert stats["Missing Co"]["job_count"] == 0
 
 
 def test_overview_avoids_nested_trend_queries(empty_db: MCFDatabase):


### PR DESCRIPTION
## Summary
- Adds short-lived API response caching for expensive read-only dashboard/trend endpoints
- Reduces multi-skill trend generation from repeated scans to one market scan
- Adds bulk company stats enrichment for similar employer profiles
- Defers similar-employer loading on Trends so employer trend data can render first
- Splits command palette/mobile nav out of the initial frontend bundle and prefetches route chunks/data on idle and nav hover/focus
- Aligns Overview to the hosted 3-month window so it shares cached overview data with Trends

## Baseline evidence
Hosted endpoint timings before this change:
- /api/overview?months=3: ~7.2s avg
- /api/stats: ~5.9s avg
- /api/skills/cloud?min_jobs=10&limit=80: ~4.6s avg
- /api/trends/skills default payload: ~15.4s avg
- /api/trends/roles default payload: ~10.1s avg
- /api/trends/companies default company: ~29.0s avg

## Validation
- poetry run pytest tests/test_market_intelligence.py tests/test_api_app.py -q
- poetry run ruff check src/api/app.py src/mcf/database.py src/mcf/pg_database.py src/mcf/embeddings/search_engine.py tests/test_api_app.py tests/test_market_intelligence.py
- npm run test:unit
- npm run test:integration
- npm run build
- npm run lint

## Notes
- Full local pytest could not complete because the isolated worktree was installed without optional ML deps; installing `ml` failed locally while building SciPy due missing OpenBLAS on Python 3.14. Focused tests pass and CI should cover the configured matrix.
- `bd sync` was attempted, but this local `bd` binary does not provide a `sync` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * API responses now load faster across all read-only endpoints
  * Pages load faster when navigating between different sections
  * Similar company profiles load more efficiently and independently

* **Updates**
  * Company trends and overview analysis now default to 3-month timeframes instead of the previous 12-month windows
  * Similar hiring profiles section now loads independently from trend data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->