### PR TITLE
Defer Trends similar profile lookup

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -71,7 +71,6 @@ export default function App() {
     (to: string) => {
       void import('@/services/api').then(
         ({
-          findSimilarCompanies,
           getCompanyTrend,
           getHealth,
           getOverview,
@@ -126,10 +125,6 @@ export default function App() {
             void queryClient.prefetchQuery({
               queryKey: ['companyTrend', TREND_PREFETCH.company, TREND_PREFETCH.months],
               queryFn: () => getCompanyTrend(TREND_PREFETCH.company, TREND_PREFETCH.months, false),
-            })
-            void queryClient.prefetchQuery({
-              queryKey: ['similarCompanies', TREND_PREFETCH.company],
-              queryFn: () => findSimilarCompanies({ company_name: TREND_PREFETCH.company, limit: 6 }),
             })
           }
 

--- a/src/frontend/src/pages/TrendsPage.tsx
+++ b/src/frontend/src/pages/TrendsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowDownRightIcon, ArrowRightIcon, ArrowUpRightIcon } from '@heroicons/react/20/solid'
 import TrendSparkline from '@/components/TrendSparkline'
-import { Card, Chip, EmptyState, Input, Select, Skeleton } from '@/components/ui'
+import { Button, Card, Chip, EmptyState, Input, Select, Skeleton } from '@/components/ui'
 import type { ChipIntent, SelectOption } from '@/components/ui'
 import { findSimilarCompanies, getCompanyTrend, getOverview, getRoleTrend, getSkillTrends } from '@/services/api'
 import { getMomentumSignal, TREND_WINDOW_OPTIONS } from '@/services/trendSignals'
@@ -128,6 +128,9 @@ export default function TrendsPage() {
   const [months, setMonths] = useState<number>(3)
   const [employmentType, setEmploymentType] = useState('')
   const [region, setRegion] = useState('')
+  const [similarProfilesCompany, setSimilarProfilesCompany] = useState<string | null>(null)
+  const companyName = companyInput.trim()
+  const similarProfilesRequested = similarProfilesCompany === companyName
 
   const skills = useMemo(
     () => skillInput.split(',').map((item) => item.trim()).filter(Boolean).slice(0, 3),
@@ -164,15 +167,15 @@ export default function TrendsPage() {
   })
 
   const companyTrend = useQuery({
-    queryKey: ['companyTrend', companyInput, months],
-    queryFn: () => getCompanyTrend(companyInput, months, false),
-    enabled: companyInput.trim().length > 0,
+    queryKey: ['companyTrend', companyName, months],
+    queryFn: () => getCompanyTrend(companyName, months, false),
+    enabled: companyName.length > 0,
   })
 
   const similarCompanies = useQuery({
-    queryKey: ['similarCompanies', companyInput],
-    queryFn: () => findSimilarCompanies({ company_name: companyInput, limit: 6 }),
-    enabled: companyInput.trim().length > 0 && companyTrend.data != null,
+    queryKey: ['similarCompanies', companyName],
+    queryFn: () => findSimilarCompanies({ company_name: companyName, limit: 6 }),
+    enabled: similarProfilesRequested && companyName.length > 0,
     staleTime: 10 * 60 * 1000,
   })
 
@@ -180,7 +183,7 @@ export default function TrendsPage() {
   const companyLatest = latestPoint(companyTrend.data?.series ?? [])
   const companyActiveMonths = activeMonths(companyTrend.data?.series ?? [])
   const companySkillSnapshots = companyTrend.data?.top_skills_by_month.filter((snapshot) => snapshot.skills.length) ?? []
-  const similarEmployerProfiles = similarCompanies.data ?? companyTrend.data?.similar_companies ?? []
+  const similarEmployerProfiles = similarProfilesRequested ? (similarCompanies.data ?? []) : []
 
   return (
     <div className="space-y-8">
@@ -403,9 +406,30 @@ export default function TrendsPage() {
               </div>
 
               <div className="rounded-[var(--radius-lg)] bg-[color:var(--surface-2)] p-5">
-                <p className="text-sm font-semibold text-[color:var(--ink)]">Similar hiring profiles</p>
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-[color:var(--ink)]">Similar hiring profiles</p>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    loading={similarCompanies.isFetching}
+                    disabled={!companyName}
+                    onClick={() => {
+                      if (similarProfilesRequested) {
+                        void similarCompanies.refetch()
+                      } else {
+                        setSimilarProfilesCompany(companyName)
+                      }
+                    }}
+                  >
+                    {similarProfilesRequested ? 'Refresh profiles' : 'Load similar profiles'}
+                  </Button>
+                </div>
                 <div className="mt-4 space-y-2">
-                  {similarCompanies.isLoading ? (
+                  {!similarProfilesRequested ? (
+                    <p className="text-sm text-[color:var(--ink-subtle)]">
+                      Load employer look-alikes only when you need the heavier comparison.
+                    </p>
+                  ) : similarCompanies.isLoading ? (
                     Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} height={58} rounded="md" />)
                   ) : similarEmployerProfiles.length ? (
                     similarEmployerProfiles.map((company) => (

--- a/src/frontend/tests/trends.similarProfiles.test.mjs
+++ b/src/frontend/tests/trends.similarProfiles.test.mjs
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict'
+import { after, before, test } from 'node:test'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const frontendDir = path.resolve(__dirname, '..')
+const serverUrl = 'http://127.0.0.1:4175'
+
+let serverProcess
+let chromium
+
+const trendPoint = (month, jobCount, overrides = {}) => ({
+  month,
+  job_count: jobCount,
+  market_share: jobCount ? 2.58 : 0,
+  median_salary_annual: jobCount ? 51000 : null,
+  momentum: jobCount ? 100 : 0,
+  momentum_status: jobCount ? 'new' : 'insufficient_baseline',
+  momentum_label: jobCount ? 'New signal' : 'No prior baseline',
+  ...overrides,
+})
+
+const trendSeries = [
+  trendPoint('2026-01', 0),
+  trendPoint('2026-02', 0),
+  trendPoint('2026-03', 70),
+]
+
+const overviewResponse = {
+  headline_metrics: {
+    total_jobs: 2711,
+    current_month_jobs: 2711,
+    unique_companies: 900,
+    unique_skills: 1200,
+    avg_salary_annual: 65000,
+  },
+  rising_skills: [],
+  rising_companies: [],
+  salary_movement: {
+    current_median_salary_annual: 65000,
+    previous_median_salary_annual: null,
+    change_pct: 0,
+  },
+  market_insights: [],
+}
+
+const companyTrendResponse = {
+  company_name: 'RECRUIT EXPERT PTE. LTD.',
+  series: trendSeries,
+  top_skills_by_month: [
+    { month: '2026-01', skills: [] },
+    { month: '2026-02', skills: [] },
+    {
+      month: '2026-03',
+      skills: [
+        { skill: 'Construction', job_count: 21, cluster_id: null },
+        { skill: 'MS Word', job_count: 16, cluster_id: null },
+      ],
+    },
+  ],
+  similar_companies: [],
+}
+
+const similarCompaniesResponse = [
+  {
+    company_name: 'BUILD TEAM PTE. LTD.',
+    similarity_score: 0.84,
+    job_count: 17,
+    avg_salary: 62000,
+    top_skills: ['Construction'],
+  },
+]
+
+async function loadPlaywright() {
+  try {
+    const module = await import('playwright')
+    return module.default ?? module
+  } catch {}
+
+  const npxRoot = path.join(process.env.HOME ?? '', '.npm', '_npx')
+  const entries = await fs.readdir(npxRoot).catch(() => [])
+  for (const entry of entries) {
+    const candidate = path.join(npxRoot, entry, 'node_modules', 'playwright', 'index.js')
+    try {
+      await fs.access(candidate)
+      const module = await import(pathToFileURL(candidate).href)
+      return module.default ?? module
+    } catch {}
+  }
+
+  throw new Error('Playwright could not be resolved. Run tests with `npx --package playwright node --test ...`.')
+}
+
+async function waitForServer(url, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for dev server at ${url}`)
+}
+
+function startDevServer() {
+  return spawn(
+    process.execPath,
+    ['node_modules/vite/bin/vite.js', '--host', '127.0.0.1', '--port', '4175', '--strictPort'],
+    {
+      cwd: frontendDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    },
+  )
+}
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch()
+  } catch (error) {
+    try {
+      return await chromium.launch({ channel: 'chrome' })
+    } catch {
+      throw error
+    }
+  }
+}
+
+function apiResponseFor(requestUrl, method) {
+  const url = new URL(requestUrl)
+
+  if (url.pathname === '/api/overview') {
+    return overviewResponse
+  }
+  if (url.pathname === '/api/trends/skills') {
+    return [
+      { skill: 'Customer Service', series: trendSeries, latest: trendSeries.at(-1) },
+      { skill: 'Microsoft Excel', series: trendSeries, latest: trendSeries.at(-1) },
+      { skill: 'Communication Skills', series: trendSeries, latest: trendSeries.at(-1) },
+    ]
+  }
+  if (url.pathname === '/api/trends/roles') {
+    return {
+      query: 'customer service',
+      series: trendSeries,
+      latest: trendSeries.at(-1),
+    }
+  }
+  if (url.pathname.startsWith('/api/trends/companies/')) {
+    assert.equal(method, 'GET')
+    assert.equal(url.searchParams.get('include_similar'), 'false')
+    return companyTrendResponse
+  }
+  if (url.pathname === '/api/companies/similar') {
+    return similarCompaniesResponse
+  }
+  if (url.pathname === '/api/stats') {
+    return {
+      total_jobs: 2711,
+      jobs_with_embeddings: 2711,
+      embedding_coverage_pct: 100,
+      unique_skills: 1200,
+      unique_companies: 900,
+      index_size_mb: 12,
+      model_version: 'test',
+    }
+  }
+  if (url.pathname === '/api/analytics/popular') {
+    return []
+  }
+  if (url.pathname === '/api/analytics/performance') {
+    return { p50_ms: 10, p90_ms: 20, p95_ms: 25, p99_ms: 30, total_queries: 5 }
+  }
+  if (url.pathname === '/api/skills/cloud') {
+    return { items: [], total_unique_skills: 0 }
+  }
+  if (url.pathname === '/health') {
+    return { status: 'ok', index_loaded: true, degraded: false }
+  }
+
+  throw new Error(`Unexpected ${method} ${url.pathname}`)
+}
+
+before(async () => {
+  ;({ chromium } = await loadPlaywright())
+  serverProcess = startDevServer()
+  await waitForServer(`${serverUrl}/trends`)
+})
+
+after(async () => {
+  if (serverProcess && !serverProcess.killed) {
+    serverProcess.kill('SIGTERM')
+    await new Promise((resolve) => serverProcess.once('exit', resolve))
+  }
+})
+
+test('loads similar employer profiles only after an explicit request', async () => {
+  let similarRequests = 0
+  const browser = await launchBrowser()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+
+  try {
+    await page.route('**/{api,health}/**', async (route) => {
+      const request = route.request()
+      const url = request.url()
+      if (new URL(url).pathname === '/api/companies/similar') {
+        similarRequests += 1
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(apiResponseFor(url, request.method())),
+      })
+    })
+
+    await page.goto(`${serverUrl}/trends`)
+    await page.getByText('RECRUIT EXPERT PTE. LTD.').waitFor()
+    await page.waitForTimeout(500)
+
+    assert.equal(similarRequests, 0)
+
+    await page.getByRole('button', { name: 'Load similar profiles' }).click()
+    await page.getByText('BUILD TEAM PTE. LTD.').waitFor()
+    assert.equal(similarRequests, 1)
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+})


### PR DESCRIPTION
## Summary\n- make the Trends similar-employer lookup opt-in instead of firing on tab load\n- remove route prefetch for the heavyweight similar-companies endpoint\n- add a Playwright regression test proving the endpoint is only called after the explicit button click\n\n## Verification\n- npm run test:unit\n- npm run test:integration\n- npm run lint\n- VITE_API_BASE_URL=https://xang1234-jobs-intelligence-api.hf.space npm run build