### PR TITLE
Avoid idle Postgres scraper transactions

### DIFF
--- a/src/mcf/historical_scraper.py
+++ b/src/mcf/historical_scraper.py
@@ -30,6 +30,7 @@ from .api_client import MCFAPIError, MCFClient, MCFNotFoundError, MCFRateLimitEr
 from .batch_logger import BatchLogger
 from .db_factory import open_database
 from .models import Job
+from .pg_database import PostgresDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +147,9 @@ class HistoricalScraper:
         """Async context manager entry."""
         self._client = MCFClient(requests_per_second=self.initial_rps)
         await self._client.__aenter__()
-        self._write_conn = self.db._connect(write_optimized=True)
-        self.batch_logger.conn = self._write_conn
+        if not isinstance(self.db, PostgresDatabase):
+            self._write_conn = self.db._connect(write_optimized=True)
+            self.batch_logger.conn = self._write_conn
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/tests/test_historical_scraper.py
+++ b/tests/test_historical_scraper.py
@@ -5,6 +5,7 @@ import asyncio
 from src.mcf import historical_scraper as historical_scraper_module
 from src.mcf.api_client import MCFAPIError, MCFNotFoundError, MCFRateLimitError
 from src.mcf.historical_scraper import HistoricalScraper
+from src.mcf.pg_database import PostgresDatabase
 
 from .factories import generate_test_job
 
@@ -26,6 +27,33 @@ class FakeClient:
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
+
+
+class FakeContextClient:
+    """Fake MCF client for context-manager setup tests."""
+
+    def __init__(self, requests_per_second: float):
+        self.requests_per_second = requests_per_second
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_):
+        self.exited = True
+
+
+class FakePostgresDatabase(PostgresDatabase):
+    """Postgres-like database that records whether a writer was opened."""
+
+    def __init__(self):
+        self.connect_calls = 0
+
+    def _connect(self, write_optimized: bool = False):
+        self.connect_calls += 1
+        raise AssertionError("Postgres scrapers should not open a long-lived writer")
 
 
 def build_scraper(db_path, **kwargs) -> HistoricalScraper:
@@ -58,6 +86,25 @@ async def close_scraper(scraper: HistoricalScraper) -> None:
 
 class TestHistoricalScraper:
     """Tests for rate-limit recovery and bound management."""
+
+    def test_postgres_context_uses_per_operation_writes(self, monkeypatch):
+        db = FakePostgresDatabase()
+        monkeypatch.setattr(historical_scraper_module, "open_database", lambda _: db)
+        monkeypatch.setattr(historical_scraper_module, "MCFClient", FakeContextClient)
+
+        scraper = HistoricalScraper("postgresql://example/mcf")
+
+        async def run():
+            await scraper.__aenter__()
+            try:
+                assert scraper._write_conn is None
+                assert scraper.batch_logger.conn is None
+            finally:
+                await scraper.__aexit__(None, None, None)
+
+        asyncio.run(run())
+
+        assert db.connect_calls == 0
 
     def test_rate_limited_sequence_does_not_block_progress(self, empty_db):
         year = 2023


### PR DESCRIPTION
## Summary
- avoid opening a long-lived writer connection for Postgres-backed historical scrapes
- keep non-Postgres write batching behavior unchanged
- add a regression test proving Postgres scrapers use per-operation writes during context setup

## Root Cause
Neon terminated the hosted scrape with idle-in-transaction timeout because the scraper opened one Postgres writer connection for the whole async scrape, then waited on MCF HTTP calls while that connection could be inside an implicit transaction.

## Validation
- poetry run ruff check src/ tests/
- poetry run ruff format --check src/ tests/
- poetry run python -m src.cli --help
- poetry run pytest --ignore=tests/test_index_manager.py --ignore=tests/test_search_engine.py --ignore=tests/test_query_expander.py --ignore=tests/test_company_centroids.py --ignore=tests/test_market_intelligence.py -x -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database connection initialization logic in the historical scraper.

* **Tests**
  * Added new test cases to verify database connection behavior with PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->