### PR TITLE
Fix hosted Neon scraper reconnects

### DIFF
--- a/src/mcf/batch_logger.py
+++ b/src/mcf/batch_logger.py
@@ -106,8 +106,8 @@ class BatchLogger:
         except Exception as e:
             logger.error(f"Failed to flush {count} attempts: {e}")
             raise
-        finally:
-            self._buffer.clear()
+
+        self._buffer.clear()
 
         return count
 

--- a/src/mcf/historical_scraper.py
+++ b/src/mcf/historical_scraper.py
@@ -21,7 +21,7 @@ import hashlib
 import logging
 import sqlite3
 from dataclasses import dataclass
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from tenacity import RetryError
 
@@ -55,6 +55,14 @@ DEFAULT_BATCH_SIZE = 250
 BOUND_DISCOVERY_WINDOW = 125
 BOUND_DISCOVERY_STEP = 25
 MAX_SEQUENCE = 9_999_999
+DATABASE_CONNECTION_ERROR_MARKERS = (
+    "connection is closed",
+    "connection is lost",
+    "closed database",
+    "server closed the connection",
+    "terminating connection",
+)
+T = TypeVar("T")
 
 
 @dataclass
@@ -147,9 +155,7 @@ class HistoricalScraper:
         """Async context manager entry."""
         self._client = MCFClient(requests_per_second=self.initial_rps)
         await self._client.__aenter__()
-        if not isinstance(self.db, PostgresDatabase):
-            self._write_conn = self.db._connect(write_optimized=True)
-            self.batch_logger.conn = self._write_conn
+        self._open_write_connection()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -157,16 +163,61 @@ class HistoricalScraper:
         # Flush any pending batch logger entries
         if self._write_conn:
             try:
-                self.batch_logger.flush()
-                self._write_conn.commit()
+                self._with_write_retry(
+                    lambda: self.batch_logger.flush(),
+                    context="final attempt flush",
+                )
             finally:
-                self._write_conn.close()
-                self._write_conn = None
-                self.batch_logger.conn = None
+                self._close_write_connection()
 
         if self._client:
             await self._client.__aexit__(exc_type, exc_val, exc_tb)
             self._client = None
+
+    def _open_write_connection(self) -> None:
+        """Open the long-lived writer connection used by scraper batches."""
+        if isinstance(self.db, PostgresDatabase):
+            self._write_conn = None
+            self.batch_logger.conn = None
+            return
+        self._write_conn = self.db._connect(write_optimized=True)
+        self.batch_logger.conn = self._write_conn
+
+    def _close_write_connection(self) -> None:
+        """Close the long-lived writer connection and detach batch logging."""
+        if self._write_conn:
+            try:
+                self._write_conn.close()
+            except Exception as exc:
+                logger.debug("Ignoring error while closing scraper writer connection: %s", exc)
+        self._write_conn = None
+        self.batch_logger.conn = None
+
+    @staticmethod
+    def _is_database_connection_error(exc: Exception) -> bool:
+        """Return True for transient closed/lost database connection errors."""
+        message = str(exc).lower()
+        return any(marker in message for marker in DATABASE_CONNECTION_ERROR_MARKERS)
+
+    def _reopen_write_connection(self, *, context: str, reason: Exception) -> None:
+        logger.warning("Reopening scraper writer after %s failed: %s", context, reason)
+        self._close_write_connection()
+        self._open_write_connection()
+
+    def _with_write_retry(self, operation: Callable[[], T], *, context: str) -> T:
+        """Run a database write, reconnecting once if the writer was dropped."""
+        for attempt in range(2):
+            try:
+                result = operation()
+                self._mark_progress_committed()
+                return result
+            except Exception as exc:
+                if attempt == 0 and self._is_database_connection_error(exc):
+                    self._reopen_write_connection(context=context, reason=exc)
+                    continue
+                raise
+
+        raise RuntimeError(f"Unreachable write retry state for {context}")
 
     @staticmethod
     def job_id_to_uuid(job_id: str) -> str:
@@ -436,25 +487,29 @@ class HistoricalScraper:
 
         # Create new session if needed
         if session_id is None and not dry_run:
-            session_id = self.db.create_historical_session(
-                year,
-                start_seq,
-                end_seq,
-                conn=self._write_conn,
+            session_id = self._with_write_retry(
+                lambda: self.db.create_historical_session(
+                    year,
+                    start_seq,
+                    end_seq,
+                    conn=self._write_conn,
+                ),
+                context=f"create historical session for {year}",
             )
-            self._mark_progress_committed()
             logger.info(f"Created new session {session_id} for year {year}")
         elif session_id and not dry_run and should_discover_bounds:
-            self.db.update_historical_progress(
-                session_id,
-                start_seq - 1,
-                jobs_found,
-                jobs_not_found,
-                consecutive_not_found,
-                end_seq=end_seq,
-                conn=self._write_conn,
+            self._with_write_retry(
+                lambda: self.db.update_historical_progress(
+                    session_id,
+                    start_seq - 1,
+                    jobs_found,
+                    jobs_not_found,
+                    consecutive_not_found,
+                    end_seq=end_seq,
+                    conn=self._write_conn,
+                ),
+                context=f"update discovered bound for {year}",
             )
-            self._mark_progress_committed()
 
         current_seq = start_seq
         checkpoint_interval = 100  # Save progress every N jobs
@@ -488,7 +543,10 @@ class HistoricalScraper:
 
                     if job:
                         # Save to database
-                        is_new, _ = self.db.upsert_job(job, conn=self._write_conn)
+                        is_new, _ = self._with_write_retry(
+                            lambda: self.db.upsert_job(job, conn=self._write_conn),
+                            context=f"upsert job {year}-{current_seq}",
+                        )
                         jobs_found += 1
                         consecutive_not_found = 0
 
@@ -547,6 +605,9 @@ class HistoricalScraper:
                         consecutive_not_found += 1
 
                 except Exception as e:
+                    if self._is_database_connection_error(e):
+                        logger.exception("Database write failed at %s-%s after retry", year, current_seq)
+                        raise
                     # Catch-all for unexpected errors - log and continue
                     logger.exception(f"Unexpected error at {year}-{current_seq}: {e}")
                     self.batch_logger.log(year, current_seq, "error", str(e))
@@ -560,17 +621,22 @@ class HistoricalScraper:
 
                 # Checkpoint periodically
                 if session_id and (current_seq - start_seq) % checkpoint_interval == 0:
-                    self.db.update_historical_progress(
-                        session_id,
-                        current_seq,
-                        jobs_found,
-                        jobs_not_found,
-                        consecutive_not_found,
-                        end_seq=end_seq,
-                        conn=self._write_conn,
+                    self._with_write_retry(
+                        lambda: self.db.update_historical_progress(
+                            session_id,
+                            current_seq,
+                            jobs_found,
+                            jobs_not_found,
+                            consecutive_not_found,
+                            end_seq=end_seq,
+                            conn=self._write_conn,
+                        ),
+                        context=f"checkpoint progress for {year}-{current_seq}",
                     )
-                    self.batch_logger.flush()
-                    self._mark_progress_committed()
+                    self._with_write_retry(
+                        lambda: self.batch_logger.flush(),
+                        context=f"checkpoint attempt flush for {year}-{current_seq}",
+                    )
 
                     # Progress callback
                     if progress_callback:
@@ -587,26 +653,32 @@ class HistoricalScraper:
 
         finally:
             # Flush batch logger
-            self.batch_logger.flush()
-            self._mark_progress_committed()
+            self._with_write_retry(
+                lambda: self.batch_logger.flush(),
+                context=f"final attempt flush for {year}",
+            )
 
             # Final progress update
             if session_id:
-                self.db.update_historical_progress(
-                    session_id,
-                    current_seq,
-                    jobs_found,
-                    jobs_not_found,
-                    consecutive_not_found,
-                    end_seq=end_seq,
-                    conn=self._write_conn,
+                self._with_write_retry(
+                    lambda: self.db.update_historical_progress(
+                        session_id,
+                        current_seq,
+                        jobs_found,
+                        jobs_not_found,
+                        consecutive_not_found,
+                        end_seq=end_seq,
+                        conn=self._write_conn,
+                    ),
+                    context=f"final progress update for {year}",
                 )
-                self._mark_progress_committed()
 
         # Mark completed if we finished normally
         if session_id and current_seq > end_seq:
-            self.db.complete_historical_session(session_id, conn=self._write_conn)
-            self._mark_progress_committed()
+            self._with_write_retry(
+                lambda: self.db.complete_historical_session(session_id, conn=self._write_conn),
+                context=f"complete historical session for {year}",
+            )
             logger.info(f"Completed year {year}")
 
         return ScrapeProgress(
@@ -806,7 +878,10 @@ class HistoricalScraper:
                     job = await self.fetch_job(year, seq)
 
                     if job:
-                        is_new, _ = self.db.upsert_job(job, conn=self._write_conn)
+                        is_new, _ = self._with_write_retry(
+                            lambda: self.db.upsert_job(job, conn=self._write_conn),
+                            context=f"upsert gap job {year}-{seq}",
+                        )
                         jobs_found += 1
                         self.batch_logger.log(year, seq, "found")
                         self.rate_limiter.on_success()
@@ -840,11 +915,18 @@ class HistoricalScraper:
                     self.rate_limiter.on_error()
                     jobs_not_found += 1
                     break
+                except Exception as e:
+                    if self._is_database_connection_error(e):
+                        logger.exception("Database write failed while retrying gap %s-%s after retry", year, seq)
+                        raise
+                    raise
 
             # Progress callback every 100 sequences
             if (i + 1) % 100 == 0:
-                self.batch_logger.flush()
-                self._mark_progress_committed()
+                self._with_write_retry(
+                    lambda: self.batch_logger.flush(),
+                    context=f"gap retry attempt flush for {year}-{seq}",
+                )
 
             if progress_callback and (i + 1) % 100 == 0:
                 progress = ScrapeProgress(
@@ -859,8 +941,10 @@ class HistoricalScraper:
                 await progress_callback(progress)
 
         # Final flush
-        self.batch_logger.flush()
-        self._mark_progress_committed()
+        self._with_write_retry(
+            lambda: self.batch_logger.flush(),
+            context=f"final gap retry attempt flush for {year}",
+        )
 
         logger.info(f"Gap retry complete for year {year}: {jobs_found:,} recovered, {jobs_not_found:,} still missing")
 

--- a/tests/test_historical_scraper.py
+++ b/tests/test_historical_scraper.py
@@ -1,9 +1,13 @@
 """Tests for the historical scraper recovery path."""
 
 import asyncio
+import sqlite3
+
+import pytest
 
 from src.mcf import historical_scraper as historical_scraper_module
 from src.mcf.api_client import MCFAPIError, MCFNotFoundError, MCFRateLimitError
+from src.mcf.batch_logger import BatchLogger
 from src.mcf.historical_scraper import HistoricalScraper
 from src.mcf.pg_database import PostgresDatabase
 
@@ -105,6 +109,66 @@ class TestHistoricalScraper:
         asyncio.run(run())
 
         assert db.connect_calls == 0
+
+    def test_batch_logger_keeps_buffer_when_flush_fails(self):
+        class FailingDB:
+            def batch_insert_attempts(self, attempts, conn=None):
+                raise sqlite3.OperationalError("connection is closed")
+
+        logger = BatchLogger(FailingDB())
+        logger.log(2026, 1, "found")
+
+        with pytest.raises(sqlite3.OperationalError):
+            logger.flush()
+
+        assert logger.pending_count == 1
+        logger._buffer.clear()
+
+    def test_scrape_year_reopens_closed_write_connection(self, empty_db, monkeypatch):
+        year = 2026
+        scraper = build_scraper(empty_db.db_path, batch_size=10)
+
+        seq1_uuid = scraper._job_uuid(year, 1)
+        seq2_uuid = scraper._job_uuid(year, 2)
+        job1 = generate_test_job(job_uuid=seq1_uuid)
+        client = FakeClient(
+            {
+                seq1_uuid: [job1],
+                seq2_uuid: [MCFNotFoundError("missing")],
+            }
+        )
+
+        original_upsert_job = scraper.db.upsert_job
+        attempts = 0
+
+        def flaky_upsert_job(job, conn=None):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                conn.close()
+                raise sqlite3.OperationalError("Cannot operate on a closed database.")
+            return original_upsert_job(job, conn=conn)
+
+        monkeypatch.setattr(scraper.db, "upsert_job", flaky_upsert_job)
+
+        async def run():
+            await attach_fake_client(scraper, client)
+            try:
+                return await scraper.scrape_year(year, start_seq=1, end_seq=2, resume=False)
+            finally:
+                await close_scraper(scraper)
+
+        progress = asyncio.run(run())
+        stats = empty_db.get_attempt_stats(year)
+
+        assert attempts == 2
+        assert progress.current_seq == 3
+        assert progress.jobs_found == 1
+        assert progress.jobs_not_found == 1
+        assert stats["found"] == 1
+        assert stats["not_found"] == 1
+        assert empty_db.get_job(seq1_uuid) is not None
+        assert client.calls == [seq1_uuid, seq2_uuid]
 
     def test_rate_limited_sequence_does_not_block_progress(self, empty_db):
         year = 2023


### PR DESCRIPTION
## Summary
- retain buffered fetch attempts when a database flush fails
- retry scraper writes once after a lost/closed database connection
- keep Postgres hosted scraping on per-operation writes while preserving SQLite writer batching

## Verification
- /Users/admin/Documents/Work/jobs-intelligence/.venv/bin/python -m pytest tests/test_historical_scraper.py -q
- /Users/admin/Documents/Work/jobs-intelligence/.venv/bin/python -m ruff check src/mcf/historical_scraper.py src/mcf/batch_logger.py tests/test_historical_scraper.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic retry logic for database write operations to recover from transient connection errors
  * Enhanced buffer retention during flush failures to prevent data loss and ensure reliable persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->